### PR TITLE
feat(gen-htpasswd): add .htpasswd generator

### DIFF
--- a/apps/gen-htpasswd/index.html
+++ b/apps/gen-htpasswd/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>htpasswd Generator - Elchika Tools</title>
+    <meta name="description" content=".htpasswd生成ツール" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/gen-htpasswd/package.json
+++ b/apps/gen-htpasswd/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "gen-htpasswd",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "type-check": "tsgo --noEmit",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
+    "test:coverage": "bun test --coverage",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "format:check": "biome format .",
+    "deploy": "bun run build && wrangler pages deploy dist --project-name=tools-gen-htpasswd"
+  },
+  "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toast": "^1.2.15",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.546.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+
+    "tailwind-merge": "^3.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.0",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.9.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/apps/gen-htpasswd/postcss.config.js
+++ b/apps/gen-htpasswd/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/gen-htpasswd/src/App.tsx
+++ b/apps/gen-htpasswd/src/App.tsx
@@ -1,0 +1,116 @@
+import { Copy, RefreshCw } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Toaster } from '@/components/ui/toaster';
+import { useToast } from '@/hooks/useToast';
+import { generateHtpasswd, validateUsername } from '@/utils/htpasswd';
+
+export default function App() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [algorithm, setAlgorithm] = useState<'sha1' | 'plain'>('sha1');
+  const [output, setOutput] = useState('');
+  const { toast } = useToast();
+
+  const usernameError = validateUsername(username);
+
+  const generate = useCallback(async () => {
+    if (usernameError) return;
+    const result = await generateHtpasswd(username, password, algorithm);
+    setOutput(result);
+  }, [username, password, algorithm, usernameError]);
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(output);
+      toast({ title: 'Copied to clipboard' });
+    } catch {
+      toast({ title: 'コピーに失敗しました', variant: 'destructive' });
+    }
+  };
+
+  const cls =
+    'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+  return (
+    <div className="min-h-screen bg-background p-8">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">.htpasswd Generator</h1>
+          <p className="text-muted-foreground">
+            Apache .htpasswd形式のパスワードハッシュを生成します。
+          </p>
+        </header>
+        <Card>
+          <CardHeader>
+            <CardTitle>Generator</CardTitle>
+            <CardDescription>ユーザー名とパスワードを入力してください。</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="username">ユーザー名</Label>
+                <input
+                  id="username"
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="admin"
+                  className={cls}
+                />
+                {username && usernameError && (
+                  <div className="text-xs text-red-500">{usernameError}</div>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">パスワード</Label>
+                <input
+                  id="password"
+                  type="text"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="password"
+                  className={cls}
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-4">
+              <div className="flex gap-2">
+                {(['sha1', 'plain'] as const).map((alg) => (
+                  <button
+                    type="button"
+                    key={alg}
+                    onClick={() => setAlgorithm(alg)}
+                    className={`px-3 py-2 rounded-md text-sm transition-colors ${algorithm === alg ? 'bg-primary text-primary-foreground' : 'hover:bg-muted border'}`}
+                  >
+                    {alg === 'sha1' ? 'SHA-1' : 'Plain'}
+                  </button>
+                ))}
+              </div>
+              <Button onClick={generate} disabled={!username || !password || !!usernameError}>
+                <RefreshCw className="mr-2 h-4 w-4" /> Generate
+              </Button>
+            </div>
+            {output && (
+              <div className="space-y-2 pt-4 border-t">
+                <Label>Output</Label>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 bg-muted rounded px-3 py-2 text-sm font-mono break-all">
+                    {output}
+                  </code>
+                  <Button size="icon" variant="outline" onClick={copyToClipboard}>
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+      <Toaster />
+    </div>
+  );
+}

--- a/apps/gen-htpasswd/src/components/ui/__tests__/button.test.tsx
+++ b/apps/gen-htpasswd/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,90 @@
+/// <reference lib="dom" />
+import { describe, test, expect, jest } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button } from '../button';
+
+describe('Button Component', () => {
+  describe('Rendering', () => {
+    test('should render with default variant', () => {
+      const { getByRole } = render(<Button>Click me</Button>);
+      expect(getByRole('button')).toBeInTheDocument();
+      expect(getByRole('button')).toHaveClass('bg-primary');
+    });
+
+    test('should render with different variants', () => {
+      const { getByRole, rerender } = render(<Button variant="destructive">Destructive</Button>);
+      expect(getByRole('button')).toHaveClass('bg-destructive');
+
+      rerender(<Button variant="outline">Outline</Button>);
+      expect(getByRole('button')).toHaveClass('border-input');
+
+      rerender(<Button variant="secondary">Secondary</Button>);
+      expect(getByRole('button')).toHaveClass('bg-secondary');
+
+      rerender(<Button variant="ghost">Ghost</Button>);
+      expect(getByRole('button')).toHaveClass('hover:bg-accent');
+
+      rerender(<Button variant="link">Link</Button>);
+      expect(getByRole('button')).toHaveClass('text-primary');
+    });
+
+    test('should render with different sizes', () => {
+      const { getByText } = render(<Button size="sm">Small</Button>);
+      const button = getByText('Small');
+      expect(button).toHaveClass('h-9');
+    });
+  });
+
+  describe('Interactions', () => {
+    test('should call onClick when clicked', async () => {
+      const handleClick = jest.fn();
+      const user = userEvent.setup();
+      
+      const { getByText } = render(<Button onClick={handleClick}>Click me</Button>);
+      const button = getByText('Click me');
+      
+      await user.click(button);
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not call onClick when disabled', async () => {
+      const handleClick = jest.fn();
+      const user = userEvent.setup();
+      
+      const { getByText } = render(<Button onClick={handleClick} disabled>Disabled</Button>);
+      const button = getByText('Disabled');
+      
+      await user.click(button);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('States', () => {
+    test('should be disabled when disabled prop is true', () => {
+      const { getByText } = render(<Button disabled>Disabled</Button>);
+      const button = getByText('Disabled');
+      expect(button).toBeDisabled();
+    });
+
+    test('should be enabled by default', () => {
+      const { getByText } = render(<Button>Enabled</Button>);
+      const button = getByText('Enabled');
+      expect(button).toBeEnabled();
+    });
+  });
+
+  describe('Custom Props', () => {
+    test('should accept className prop', () => {
+      const { getByText } = render(<Button className="custom-class">Button</Button>);
+      const button = getByText('Button');
+      expect(button).toHaveClass('custom-class');
+    });
+
+    test('should accept type prop', () => {
+      const { getByText } = render(<Button type="submit">Submit</Button>);
+      const button = getByText('Submit');
+      expect(button).toHaveAttribute('type', 'submit');
+    });
+  });
+});

--- a/apps/gen-htpasswd/src/components/ui/__tests__/card.test.tsx
+++ b/apps/gen-htpasswd/src/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,77 @@
+/// <reference lib="dom" />
+import { describe, test, expect } from 'bun:test';
+import { render } from '@testing-library/react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '../card';
+
+describe('Card Components', () => {
+  describe('Card', () => {
+    test('should render card', () => {
+      const { getByText } = render(<Card>Card Content</Card>);
+      expect(getByText('Card Content')).toBeInTheDocument();
+    });
+
+    test('should accept className prop', () => {
+      const { container } = render(<Card className="custom-class">Content</Card>);
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+  });
+
+  describe('CardHeader', () => {
+    test('should render card header', () => {
+      const { getByText } = render(<CardHeader>Header</CardHeader>);
+      expect(getByText('Header')).toBeInTheDocument();
+    });
+  });
+
+  describe('CardTitle', () => {
+    test('should render card title', () => {
+      const { getByText } = render(<CardTitle>Title</CardTitle>);
+      expect(getByText('Title')).toBeInTheDocument();
+    });
+  });
+
+  describe('CardDescription', () => {
+    test('should render card description', () => {
+      const { getByText } = render(<CardDescription>Description</CardDescription>);
+      expect(getByText('Description')).toBeInTheDocument();
+    });
+  });
+
+  describe('CardContent', () => {
+    test('should render card content', () => {
+      const { getByText } = render(<CardContent>Content</CardContent>);
+      expect(getByText('Content')).toBeInTheDocument();
+    });
+  });
+
+  describe('CardFooter', () => {
+    test('should render card footer', () => {
+      const { getByText } = render(<CardFooter>Footer</CardFooter>);
+      expect(getByText('Footer')).toBeInTheDocument();
+    });
+  });
+
+  describe('Complete Card', () => {
+    test('should render complete card with all parts', () => {
+      const { getByText } = render(
+        <Card>
+          <CardHeader>
+            <CardTitle>Card Title</CardTitle>
+            <CardDescription>Card Description</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p>Main Content</p>
+          </CardContent>
+          <CardFooter>
+            <p>Footer Content</p>
+          </CardFooter>
+        </Card>
+      );
+
+      expect(getByText('Card Title')).toBeInTheDocument();
+      expect(getByText('Card Description')).toBeInTheDocument();
+      expect(getByText('Main Content')).toBeInTheDocument();
+      expect(getByText('Footer Content')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/gen-htpasswd/src/components/ui/__tests__/input.test.tsx
+++ b/apps/gen-htpasswd/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,98 @@
+/// <reference lib="dom" />
+import { describe, test, expect, jest } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Input } from '../input';
+
+describe('Input Component', () => {
+  describe('Rendering', () => {
+    test('should render input element', () => {
+      const { getByRole } = render(<Input />);
+      expect(getByRole('textbox')).toBeInTheDocument();
+    });
+
+    test('should render with placeholder', () => {
+      const { getByPlaceholderText } = render(<Input placeholder="Enter text" />);
+      expect(getByPlaceholderText('Enter text')).toBeInTheDocument();
+    });
+
+    test('should render with value', () => {
+      const { getByDisplayValue } = render(<Input value="test value" readOnly />);
+      expect(getByDisplayValue('test value')).toBeInTheDocument();
+    });
+  });
+
+  describe('Types', () => {
+    test('should render with different types', () => {
+      const { rerender, getByRole, getByPlaceholderText } = render(<Input type="text" placeholder="text" />);
+      expect(getByRole('textbox')).toHaveAttribute('type', 'text');
+
+      rerender(<Input type="password" placeholder="password" />);
+      // Password input doesn't have 'textbox' role by default
+      expect(getByPlaceholderText('password')).toHaveAttribute('type', 'password');
+
+      rerender(<Input type="email" placeholder="email" />);
+      expect(getByRole('textbox')).toHaveAttribute('type', 'email');
+
+      rerender(<Input type="number" placeholder="number" />);
+      expect(getByRole('spinbutton')).toHaveAttribute('type', 'number');
+    });
+  });
+
+  describe('Interactions', () => {
+    test('should call onChange when typing', async () => {
+      const handleChange = jest.fn();
+      const user = userEvent.setup();
+      
+      const { getByRole } = render(<Input onChange={handleChange} />);
+      const input = getByRole('textbox');
+      
+      await user.type(input, 'a');
+      expect(handleChange).toHaveBeenCalled();
+    });
+
+    test('should update value when typing', async () => {
+      const user = userEvent.setup();
+      
+      const { getByRole } = render(<Input />);
+      const input = getByRole('textbox');
+      
+      await user.type(input, 'test');
+      expect(input).toHaveValue('test');
+    });
+  });
+
+  describe('States', () => {
+    test('should be disabled when disabled prop is true', () => {
+      const { getByRole } = render(<Input disabled />);
+      expect(getByRole('textbox')).toBeDisabled();
+    });
+
+    test('should be enabled by default', () => {
+      const { getByRole } = render(<Input />);
+      expect(getByRole('textbox')).toBeEnabled();
+    });
+
+    test('should be readonly when readOnly prop is true', () => {
+      const { getByRole } = render(<Input readOnly />);
+      expect(getByRole('textbox')).toHaveAttribute('readonly');
+    });
+  });
+
+  describe('Custom Props', () => {
+    test('should accept className prop', () => {
+      const { getByRole } = render(<Input className="custom-class" />);
+      expect(getByRole('textbox')).toHaveClass('custom-class');
+    });
+
+    test('should accept id prop', () => {
+      const { getByRole } = render(<Input id="test-id" />);
+      expect(getByRole('textbox')).toHaveAttribute('id', 'test-id');
+    });
+
+    test('should accept name prop', () => {
+      const { getByRole } = render(<Input name="test-name" />);
+      expect(getByRole('textbox')).toHaveAttribute('name', 'test-name');
+    });
+  });
+});

--- a/apps/gen-htpasswd/src/components/ui/button.stories.tsx
+++ b/apps/gen-htpasswd/src/components/ui/button.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+
+const meta = {
+  title: 'UI/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg', 'icon'],
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Button',
+    variant: 'default',
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    children: 'Delete',
+    variant: 'destructive',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    children: 'Outline',
+    variant: 'outline',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    children: 'Secondary',
+    variant: 'secondary',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    children: 'Ghost',
+    variant: 'ghost',
+  },
+};
+
+export const Link: Story = {
+  args: {
+    children: 'Link',
+    variant: 'link',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    children: 'Small',
+    size: 'sm',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    children: 'Large',
+    size: 'lg',
+  },
+};
+
+export const Icon: Story = {
+  args: {
+    children: '🔍',
+    size: 'icon',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <Button variant="default">Default</Button>
+        <Button variant="destructive">Destructive</Button>
+        <Button variant="outline">Outline</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="link">Link</Button>
+      </div>
+      <div className="flex gap-2 items-center">
+        <Button size="sm">Small</Button>
+        <Button size="default">Default</Button>
+        <Button size="lg">Large</Button>
+        <Button size="icon">🔍</Button>
+      </div>
+    </div>
+  ),
+};

--- a/apps/gen-htpasswd/src/components/ui/button.tsx
+++ b/apps/gen-htpasswd/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/apps/gen-htpasswd/src/components/ui/card.stories.tsx
+++ b/apps/gen-htpasswd/src/components/ui/card.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from './card';
+import { Button } from './button';
+
+const meta = {
+  title: 'UI/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>Card Title</CardTitle>
+        <CardDescription>Card Description</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>Card content goes here.</p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>Create Project</CardTitle>
+        <CardDescription>Deploy your new project in one-click.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>Configure your project settings below.</p>
+      </CardContent>
+      <CardFooter className="flex justify-between">
+        <Button variant="outline">Cancel</Button>
+        <Button>Deploy</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const Simple: Story = {
+  render: () => (
+    <Card className="w-[350px] p-6">
+      <p>A simple card with just content.</p>
+    </Card>
+  ),
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Card className="w-[350px]">
+        <CardHeader>
+          <CardTitle>First Card</CardTitle>
+          <CardDescription>This is the first card</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>First card content</p>
+        </CardContent>
+      </Card>
+      <Card className="w-[350px]">
+        <CardHeader>
+          <CardTitle>Second Card</CardTitle>
+          <CardDescription>This is the second card</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>Second card content</p>
+        </CardContent>
+      </Card>
+    </div>
+  ),
+};

--- a/apps/gen-htpasswd/src/components/ui/card.tsx
+++ b/apps/gen-htpasswd/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/apps/gen-htpasswd/src/components/ui/input.stories.tsx
+++ b/apps/gen-htpasswd/src/components/ui/input.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from './input';
+import { Label } from './label';
+
+const meta = {
+  title: 'UI/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter text...',
+  },
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-2">
+      <Label htmlFor="email">Email</Label>
+      <Input id="email" type="email" placeholder="email@example.com" />
+    </div>
+  ),
+};
+
+export const Number: Story = {
+  args: {
+    type: 'number',
+    placeholder: '0',
+  },
+};
+
+export const Password: Story = {
+  args: {
+    type: 'password',
+    placeholder: 'Enter password',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disabled input',
+    disabled: true,
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    value: 'Pre-filled value',
+  },
+};
+
+export const AllTypes: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="text">Text</Label>
+        <Input id="text" type="text" placeholder="Text input" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" placeholder="email@example.com" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">Password</Label>
+        <Input id="password" type="password" placeholder="Password" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="number">Number</Label>
+        <Input id="number" type="number" placeholder="0" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="url">URL</Label>
+        <Input id="url" type="url" placeholder="https://example.com" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="disabled">Disabled</Label>
+        <Input id="disabled" placeholder="Disabled input" disabled />
+      </div>
+    </div>
+  ),
+};

--- a/apps/gen-htpasswd/src/components/ui/input.tsx
+++ b/apps/gen-htpasswd/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/apps/gen-htpasswd/src/components/ui/label.stories.tsx
+++ b/apps/gen-htpasswd/src/components/ui/label.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Label } from './label';
+import { Input } from './input';
+
+const meta = {
+  title: 'UI/Label',
+  component: Label,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Label',
+  },
+};
+
+export const WithInput: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-2">
+      <Label htmlFor="username">Username</Label>
+      <Input id="username" placeholder="Enter your username" />
+    </div>
+  ),
+};
+
+export const Required: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-2">
+      <Label htmlFor="email">
+        Email <span className="text-destructive">*</span>
+      </Label>
+      <Input id="email" type="email" placeholder="email@example.com" required />
+    </div>
+  ),
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="name">Name</Label>
+        <Input id="name" placeholder="Your name" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" type="email" placeholder="email@example.com" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="message">Message</Label>
+        <Input id="message" placeholder="Your message" />
+      </div>
+    </div>
+  ),
+};

--- a/apps/gen-htpasswd/src/components/ui/label.tsx
+++ b/apps/gen-htpasswd/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/apps/gen-htpasswd/src/components/ui/select.stories.tsx
+++ b/apps/gen-htpasswd/src/components/ui/select.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from './select';
+import { Label } from './label';
+
+const meta = {
+  title: 'UI/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[180px]">
+        <SelectValue placeholder="Select an option" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="option1">Option 1</SelectItem>
+        <SelectItem value="option2">Option 2</SelectItem>
+        <SelectItem value="option3">Option 3</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const WithLabel: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-2">
+      <Label htmlFor="framework">Framework</Label>
+      <Select>
+        <SelectTrigger id="framework">
+          <SelectValue placeholder="Select a framework" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="react">React</SelectItem>
+          <SelectItem value="vue">Vue</SelectItem>
+          <SelectItem value="angular">Angular</SelectItem>
+          <SelectItem value="svelte">Svelte</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+};
+
+export const WithGroups: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[280px]">
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Fruits</SelectLabel>
+          <SelectItem value="apple">Apple</SelectItem>
+          <SelectItem value="banana">Banana</SelectItem>
+          <SelectItem value="orange">Orange</SelectItem>
+        </SelectGroup>
+        <SelectGroup>
+          <SelectLabel>Vegetables</SelectLabel>
+          <SelectItem value="carrot">Carrot</SelectItem>
+          <SelectItem value="potato">Potato</SelectItem>
+          <SelectItem value="tomato">Tomato</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const MultipleSelects: Story = {
+  render: () => (
+    <div className="w-[350px] space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="country">Country</Label>
+        <Select>
+          <SelectTrigger id="country">
+            <SelectValue placeholder="Select a country" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="us">United States</SelectItem>
+            <SelectItem value="uk">United Kingdom</SelectItem>
+            <SelectItem value="jp">Japan</SelectItem>
+            <SelectItem value="fr">France</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="language">Language</Label>
+        <Select>
+          <SelectTrigger id="language">
+            <SelectValue placeholder="Select a language" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="en">English</SelectItem>
+            <SelectItem value="ja">Japanese</SelectItem>
+            <SelectItem value="fr">French</SelectItem>
+            <SelectItem value="de">German</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  ),
+};

--- a/apps/gen-htpasswd/src/components/ui/select.tsx
+++ b/apps/gen-htpasswd/src/components/ui/select.tsx
@@ -1,0 +1,151 @@
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/apps/gen-htpasswd/src/components/ui/toast.tsx
+++ b/apps/gen-htpasswd/src/components/ui/toast.tsx
@@ -1,0 +1,122 @@
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      className
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  {
+    variants: {
+      variant: {
+        default: 'border bg-background text-foreground',
+        destructive:
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
+        success: 'border-green-500 bg-green-50 text-green-900',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      className
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title ref={ref} className={cn('text-sm font-semibold', className)} {...props} />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+};

--- a/apps/gen-htpasswd/src/components/ui/toaster.tsx
+++ b/apps/gen-htpasswd/src/components/ui/toaster.tsx
@@ -1,0 +1,29 @@
+import { useToast } from '@hooks/useToast';
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from './toast';
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(({ id, title, description, action, ...props }) => (
+        <Toast key={id} {...props}>
+          <div className="grid gap-1">
+            {title && <ToastTitle>{title}</ToastTitle>}
+            {description && <ToastDescription>{description}</ToastDescription>}
+          </div>
+          {action}
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/apps/gen-htpasswd/src/hooks/useToast.ts
+++ b/apps/gen-htpasswd/src/hooks/useToast.ts
@@ -1,0 +1,183 @@
+import type { ToastActionElement, ToastProps } from '@components/ui/toast';
+import * as React from 'react';
+
+const TOAST_LIMIT = 3;
+const TOAST_REMOVE_DELAY = 5000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+const _actionTypes = {
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+} as const;
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+
+type ActionType = typeof _actionTypes;
+
+type Action =
+  | {
+      type: ActionType['ADD_TOAST'];
+      toast: ToasterToast;
+    }
+  | {
+      type: ActionType['UPDATE_TOAST'];
+      toast: Partial<ToasterToast>;
+    }
+  | {
+      type: ActionType['DISMISS_TOAST'];
+      toastId?: ToasterToast['id'] | undefined;
+    }
+  | {
+      type: ActionType['REMOVE_TOAST'];
+      toastId?: ToasterToast['id'] | undefined;
+    };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: 'REMOVE_TOAST',
+      toastId: toastId,
+    });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'ADD_TOAST':
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)),
+      };
+
+    case 'DISMISS_TOAST': {
+      const { toastId } = action;
+
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      };
+    }
+    case 'REMOVE_TOAST':
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, 'id'>;
+
+function toast({ ...props }: Toast) {
+  const id = genId();
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: 'UPDATE_TOAST',
+      toast: { ...props, id },
+    });
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id });
+
+  dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss();
+      },
+    },
+  });
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, []);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
+  };
+}
+
+export { useToast, toast };

--- a/apps/gen-htpasswd/src/index.css
+++ b/apps/gen-htpasswd/src/index.css
@@ -1,0 +1,69 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/gen-htpasswd/src/lib/utils.ts
+++ b/apps/gen-htpasswd/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/gen-htpasswd/src/main.tsx
+++ b/apps/gen-htpasswd/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found. Make sure your HTML contains an element with id="root"');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/apps/gen-htpasswd/src/utils/__tests__/htpasswd.test.ts
+++ b/apps/gen-htpasswd/src/utils/__tests__/htpasswd.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { generateHtpasswd, validateUsername } from '../htpasswd';
+
+describe('generateHtpasswd', () => {
+  test('sha1 format', async () => {
+    const result = await generateHtpasswd('admin', 'password', 'sha1');
+    expect(result).toMatch(/^admin:\{SHA\}.+$/);
+  });
+
+  test('plain format', async () => {
+    const result = await generateHtpasswd('admin', 'password', 'plain');
+    expect(result).toBe('admin:password');
+  });
+
+  test('empty username returns empty', async () => {
+    expect(await generateHtpasswd('', 'pass', 'sha1')).toBe('');
+  });
+
+  test('empty password returns empty', async () => {
+    expect(await generateHtpasswd('user', '', 'sha1')).toBe('');
+  });
+
+  test('sha1 produces consistent hash', async () => {
+    const r1 = await generateHtpasswd('test', 'pass', 'sha1');
+    const r2 = await generateHtpasswd('test', 'pass', 'sha1');
+    expect(r1).toBe(r2);
+  });
+});
+
+describe('validateUsername', () => {
+  test('valid username', () => {
+    expect(validateUsername('admin')).toBeNull();
+  });
+  test('valid with dots/dashes', () => {
+    expect(validateUsername('user.name-1')).toBeNull();
+  });
+  test('empty', () => {
+    expect(validateUsername('')).not.toBeNull();
+  });
+  test('colon rejected', () => {
+    expect(validateUsername('user:name')).not.toBeNull();
+  });
+  test('spaces rejected', () => {
+    expect(validateUsername('user name')).not.toBeNull();
+  });
+});

--- a/apps/gen-htpasswd/src/utils/htpasswd.ts
+++ b/apps/gen-htpasswd/src/utils/htpasswd.ts
@@ -1,0 +1,33 @@
+async function sha1Hash(message: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+  const hashArray = new Uint8Array(hashBuffer);
+  let binary = '';
+  for (const byte of hashArray) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export async function generateHtpasswd(
+  username: string,
+  password: string,
+  algorithm: 'sha1' | 'plain'
+): Promise<string> {
+  if (!username || !password) return '';
+
+  if (algorithm === 'sha1') {
+    const hash = await sha1Hash(password);
+    return `${username}:{SHA}${hash}`;
+  }
+
+  return `${username}:${password}`;
+}
+
+export function validateUsername(username: string): string | null {
+  if (!username) return 'ユーザー名を入力してください';
+  if (username.includes(':')) return 'ユーザー名にコロンは使用できません';
+  if (!/^[a-zA-Z0-9._-]+$/.test(username)) return '英数字と.-_のみ使用可能です';
+  return null;
+}

--- a/apps/gen-htpasswd/src/vite-env.d.ts
+++ b/apps/gen-htpasswd/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/gen-htpasswd/tailwind.config.js
+++ b/apps/gen-htpasswd/tailwind.config.js
@@ -1,0 +1,57 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        chart: {
+          1: 'hsl(var(--chart-1))',
+          2: 'hsl(var(--chart-2))',
+          3: 'hsl(var(--chart-3))',
+          4: 'hsl(var(--chart-4))',
+          5: 'hsl(var(--chart-5))',
+        },
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};

--- a/apps/gen-htpasswd/tsconfig.json
+++ b/apps/gen-htpasswd/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+
+    /* Path aliases - tsgo compatible */
+    "paths": {
+      "*": ["./*"],
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@types": ["./src/types"],
+      "@config/*": ["./src/config/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@services/*": ["./src/services/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/gen-htpasswd/vite.config.ts
+++ b/apps/gen-htpasswd/vite.config.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  // Pages直接アクセス用にルートパスを使用
+  base: '/',
+  server: {
+    port: 5226,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@components': path.resolve(__dirname, './src/components'),
+      '@utils': path.resolve(__dirname, './src/utils'),
+      '@types': path.resolve(__dirname, './src/types'),
+      '@config': path.resolve(__dirname, './src/config'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@services': path.resolve(__dirname, './src/services'),
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: false,
+    minify: 'esbuild',
+    rollupOptions: {
+      output: {
+        manualChunks: undefined,
+      },
+    },
+  },
+});

--- a/apps/gen-htpasswd/wrangler.toml
+++ b/apps/gen-htpasswd/wrangler.toml
@@ -1,0 +1,7 @@
+name = "tools-gen-htpasswd"
+compatibility_date = "2024-10-19"
+
+# Cloudflare Pages Configuration
+# Deploy: wrangler pages deploy dist --project-name=tools-gen-htpasswd
+# Build output directory: dist
+# Framework: React + Vite


### PR DESCRIPTION
## Summary
- .htpasswd生成ツールを追加
- SHA-1/Plain対応、ユーザー名バリデーション

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)