### PR TITLE
docs: add README.md and CLAUDE.md to packages/router

### DIFF
--- a/packages/router/CLAUDE.md
+++ b/packages/router/CLAUDE.md
@@ -1,0 +1,37 @@
+# Router
+
+Cloudflare Workers リバースプロキシ。`tools.elchika.app/<tool-name>` を各ツールの Cloudflare Pages にルーティング。
+
+## アーキテクチャ
+
+- Cloudflare Workers + Hono v4
+- TypeScript
+- 各ツールは `tools-<tool-name>.elchika.app` に個別デプロイ
+- このルーターが `tools.elchika.app` のカスタムドメインで単一エントリポイントを提供
+
+## 主要ファイル
+
+- `src/index.ts` - Hono app エントリポイント (ミドルウェア, ルーティング, エラーハンドリング)
+- `src/config/apps.ts` - ツール一覧定義 (APPS_CONFIG 配列)
+- `src/utils/proxy.ts` - プロキシハンドラー (createProxyHandler)
+- `src/views/ToolsListView.ts` - ルートページHTML生成
+
+## コマンド
+
+```bash
+bun run dev        # Wrangler dev server
+bun run type-check # 型チェック
+bun run deploy     # ビルド + Wrangler deploy
+bun test           # テスト
+```
+
+## ツール追加手順
+
+1. `src/config/apps.ts` の `APPS_CONFIG` 配列にエントリ追加
+2. `bun run deploy` でルーター再デプロイ
+
+## Gotchas
+
+- CORS は全オリジン許可 (`origin: '*'`)。本番で制限が必要な場合は `src/index.ts` を修正
+- ルーターはプロキシのみ。各ツールのビルド/デプロイは `apps/<tool-name>` で個別に行う
+- `wrangler.toml` の `pattern = "tools.elchika.app"` がカスタムドメイン設定

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,0 +1,83 @@
+# Router
+
+Cloudflare Workers 上で動作するリバースプロキシルーター。`tools.elchika.app/<tool-name>` へのリクエストを各ツールの Cloudflare Pages プロジェクトにプロキシする。
+
+## アーキテクチャ
+
+```
+tools.elchika.app
+  ├── /              → ツール一覧ページ (HTML)
+  ├── /health        → ヘルスチェック (JSON)
+  ├── /<tool-name>/* → 各ツールの Cloudflare Pages へプロキシ
+  └── 404            → エラーレスポンス (JSON)
+```
+
+各ツールは `tools-<tool-name>.elchika.app` に個別デプロイされており、このルーターが単一ドメインでのアクセスを提供する。
+
+## 技術スタック
+
+- **ランタイム**: Cloudflare Workers
+- **フレームワーク**: [Hono](https://hono.dev/) v4
+- **言語**: TypeScript
+- **デプロイ**: Wrangler
+
+## 開発
+
+```bash
+# 依存関係のインストール (ルートから)
+bun install
+
+# 開発サーバー起動
+cd packages/router
+bun run dev
+
+# 型チェック
+bun run type-check
+
+# デプロイ
+bun run deploy
+```
+
+## テスト
+
+```bash
+bun test
+```
+
+## ディレクトリ構成
+
+```
+packages/router/
+  src/
+    index.ts              # エントリポイント (Hono app)
+    config/
+      apps.ts             # ツール一覧定義 (パス, URL, 表示名)
+    utils/
+      proxy.ts            # プロキシハンドラー
+      __tests__/           # ユニットテスト
+    views/
+      ToolsListView.ts    # ツール一覧HTML生成
+    __tests__/             # 統合テスト
+  package.json
+  tsconfig.json
+  wrangler.toml
+```
+
+## ツールの追加方法
+
+`src/config/apps.ts` の `APPS_CONFIG` 配列にエントリを追加する:
+
+```typescript
+{
+  path: '/new-tool',
+  url: 'https://tools-new-tool.elchika.app',
+  name: 'ツール名',
+  icon: '🔧',
+  displayName: 'New Tool',
+  description: 'ツールの説明',
+}
+```
+
+## ライセンス
+
+MIT


### PR DESCRIPTION
## Summary

- `packages/router/` に開発者向け README.md とAI向け CLAUDE.md を追加
- Hono + Cloudflare Workers リバースプロキシルーターのドキュメント

| ファイル | 対象 | 内容 |
|----------|------|------|
| `packages/router/README.md` | 開発者 | アーキテクチャ図、セットアップ、ディレクトリ構成、ツール追加方法 |
| `packages/router/CLAUDE.md` | AI | 主要ファイル、コマンド、Gotchas |

## Test plan

- [ ] README.md の記載コマンドが正しいこと
- [ ] CLAUDE.md の主要ファイルパスが実在すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)