### PR TITLE
feat: add MCP server for 39 text/encode/hash/crypto tools

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "description": "MCP server for Elchika Tools",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "fetch-to-node": "^2.1.0",
+    "hono": "^4.6.14",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241205.0",
+    "vitest": "^3.0.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/packages/mcp-server/src/__tests__/crypto.test.ts
+++ b/packages/mcp-server/src/__tests__/crypto.test.ts
@@ -1,16 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createMcpServer } from '../mcp';
-
-async function callTool(name: string, args: Record<string, unknown>) {
-  const server = createMcpServer();
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  await server.connect(serverTransport);
-  const client = new Client({ name: 'test', version: '1.0.0' });
-  await client.connect(clientTransport);
-  return client.callTool({ name, arguments: args });
-}
+import { callTool } from './test-helpers';
 
 describe('crypto tools', () => {
   test('caesar encrypt/decrypt round trip', async () => {

--- a/packages/mcp-server/src/__tests__/crypto.test.ts
+++ b/packages/mcp-server/src/__tests__/crypto.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../mcp';
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test', version: '1.0.0' });
+  await client.connect(clientTransport);
+  return client.callTool({ name, arguments: args });
+}
+
+describe('crypto tools', () => {
+  test('caesar encrypt/decrypt round trip', async () => {
+    const encrypted = await callTool('cipher_caesar_encrypt', { text: 'Hello', shift: 3 });
+    const encText = (encrypted.content as Array<{ type: string; text: string }>)[0].text;
+    expect(encText).toBe('Khoor');
+    const decrypted = await callTool('cipher_caesar_decrypt', { text: encText, shift: 3 });
+    expect(decrypted.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  test('caesar bruteforce returns valid JSON with 26 entries', async () => {
+    const result = await callTool('cipher_caesar_bruteforce', { text: 'Khoor' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed).toHaveLength(26);
+    expect(parsed[0]).toHaveProperty('shift');
+    expect(parsed[0]).toHaveProperty('result');
+  });
+
+  test('rot13 HELLO -> URYYB', async () => {
+    const result = await callTool('cipher_rot', { text: 'HELLO', variant: 'rot13' });
+    expect(result.content).toEqual([{ type: 'text', text: 'URYYB' }]);
+  });
+
+  test('rot18 includes digit rotation', async () => {
+    const result = await callTool('cipher_rot', { text: 'ABC123', variant: 'rot18' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toBe('NOP678');
+  });
+
+  test('rot47', async () => {
+    const result = await callTool('cipher_rot', { text: 'Hello!', variant: 'rot47' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text.length).toBe(6);
+    expect(text).not.toBe('Hello!');
+  });
+
+  test('vigenere encrypt/decrypt round trip', async () => {
+    const encrypted = await callTool('cipher_vigenere_encrypt', { text: 'HELLO', key: 'KEY' });
+    const encText = (encrypted.content as Array<{ type: string; text: string }>)[0].text;
+    const decrypted = await callTool('cipher_vigenere_decrypt', { text: encText, key: 'KEY' });
+    expect(decrypted.content).toEqual([{ type: 'text', text: 'HELLO' }]);
+  });
+
+  test('atbash ABC -> ZYX', async () => {
+    const result = await callTool('cipher_atbash', { text: 'ABC' });
+    expect(result.content).toEqual([{ type: 'text', text: 'ZYX' }]);
+  });
+
+  test('atbash is symmetric', async () => {
+    const first = await callTool('cipher_atbash', { text: 'Hello' });
+    const firstText = (first.content as Array<{ type: string; text: string }>)[0].text;
+    const second = await callTool('cipher_atbash', { text: firstText });
+    expect(second.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  test('affine encrypt with invalid a returns isError', async () => {
+    const result = await callTool('cipher_affine_encrypt', { text: 'Hello', a: 2, b: 3 });
+    expect(result.isError).toBe(true);
+  });
+
+  test('affine encrypt/decrypt round trip', async () => {
+    const encrypted = await callTool('cipher_affine_encrypt', { text: 'Hello', a: 5, b: 8 });
+    const encText = (encrypted.content as Array<{ type: string; text: string }>)[0].text;
+    expect(encrypted.isError).toBeUndefined();
+    const decrypted = await callTool('cipher_affine_decrypt', { text: encText, a: 5, b: 8 });
+    expect(decrypted.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  test('affine decrypt with invalid a returns isError', async () => {
+    const result = await callTool('cipher_affine_decrypt', { text: 'Hello', a: 4, b: 3 });
+    expect(result.isError).toBe(true);
+  });
+
+  test('rail fence encrypt/decrypt round trip', async () => {
+    const encrypted = await callTool('cipher_rail_fence_encrypt', {
+      text: 'HELLO WORLD',
+      rails: 3,
+    });
+    const encText = (encrypted.content as Array<{ type: string; text: string }>)[0].text;
+    expect(encText).not.toBe('HELLO WORLD');
+    const decrypted = await callTool('cipher_rail_fence_decrypt', { text: encText, rails: 3 });
+    expect(decrypted.content).toEqual([{ type: 'text', text: 'HELLO WORLD' }]);
+  });
+
+  test('enigma with defaults produces output different from input', async () => {
+    const result = await callTool('cipher_enigma', { text: 'HELLO' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toHaveLength(5);
+    expect(text).not.toBe('HELLO');
+    // Output should be uppercase letters
+    expect(text).toMatch(/^[A-Z]+$/);
+  });
+
+  test('enigma with custom rotors and positions', async () => {
+    const result = await callTool('cipher_enigma', {
+      text: 'ABC',
+      rotors: ['III', 'II', 'I'],
+      positions: [1, 2, 3],
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toHaveLength(3);
+    expect(text).toMatch(/^[A-Z]+$/);
+  });
+});

--- a/packages/mcp-server/src/__tests__/encode.test.ts
+++ b/packages/mcp-server/src/__tests__/encode.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../mcp';
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test', version: '1.0.0' });
+  await client.connect(clientTransport);
+  return client.callTool({ name, arguments: args });
+}
+
+describe('encode tools', () => {
+  test('encode_base64', async () => {
+    const result = await callTool('encode_base64', { text: 'Hello' });
+    expect(result.content).toEqual([{ type: 'text', text: 'SGVsbG8=' }]);
+  });
+
+  test('decode_base64', async () => {
+    const result = await callTool('decode_base64', { text: 'SGVsbG8=' });
+    expect(result.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  test('encode_base32 / decode_base32 round trip', async () => {
+    const encoded = await callTool('encode_base32', { text: 'Hello' });
+    const encodedText = (encoded.content as Array<{ type: string; text: string }>)[0].text;
+    const decoded = await callTool('decode_base32', { text: encodedText });
+    expect(decoded.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  test('encode_binary', async () => {
+    const result = await callTool('encode_binary', { text: 'AB' });
+    expect(result.content).toEqual([{ type: 'text', text: '01000001 01000010' }]);
+  });
+
+  test('decode_binary', async () => {
+    const result = await callTool('decode_binary', { text: '01000001 01000010' });
+    expect(result.content).toEqual([{ type: 'text', text: 'AB' }]);
+  });
+
+  test('encode_hex', async () => {
+    const result = await callTool('encode_hex', { text: 'AB' });
+    expect(result.content).toEqual([{ type: 'text', text: '41 42' }]);
+  });
+
+  test('decode_hex', async () => {
+    const result = await callTool('decode_hex', { text: '41 42' });
+    expect(result.content).toEqual([{ type: 'text', text: 'AB' }]);
+  });
+
+  test('encode_decimal', async () => {
+    const result = await callTool('encode_decimal', { text: 'AB' });
+    expect(result.content).toEqual([{ type: 'text', text: '65 66' }]);
+  });
+
+  test('decode_decimal', async () => {
+    const result = await callTool('decode_decimal', { text: '65 66' });
+    expect(result.content).toEqual([{ type: 'text', text: 'AB' }]);
+  });
+
+  test('encode_html_entity', async () => {
+    const result = await callTool('encode_html_entity', { text: '<div>' });
+    expect(result.content).toEqual([{ type: 'text', text: '&lt;div&gt;' }]);
+  });
+
+  test('decode_html_entity', async () => {
+    const result = await callTool('decode_html_entity', { text: '&lt;div&gt;' });
+    expect(result.content).toEqual([{ type: 'text', text: '<div>' }]);
+  });
+
+  test('encode_morse', async () => {
+    const result = await callTool('encode_morse', { text: 'SOS' });
+    expect(result.content).toEqual([{ type: 'text', text: '... --- ...' }]);
+  });
+
+  test('decode_morse', async () => {
+    const result = await callTool('decode_morse', { text: '... --- ...' });
+    expect(result.content).toEqual([{ type: 'text', text: 'SOS' }]);
+  });
+
+  test('encode_punycode', async () => {
+    const result = await callTool('encode_punycode', { domain: 'example.com' });
+    expect(result.content).toEqual([{ type: 'text', text: 'example.com' }]);
+  });
+
+  test('encode_unicode_escape', async () => {
+    const result = await callTool('encode_unicode_escape', { text: 'A' });
+    expect(result.content).toEqual([{ type: 'text', text: '\\u0041' }]);
+  });
+
+  test('decode_unicode_escape', async () => {
+    const result = await callTool('decode_unicode_escape', { text: '\\u0041' });
+    expect(result.content).toEqual([{ type: 'text', text: 'A' }]);
+  });
+
+  test('encode_url', async () => {
+    const result = await callTool('encode_url', { text: 'hello world' });
+    expect(result.content).toEqual([{ type: 'text', text: 'hello%20world' }]);
+  });
+
+  test('decode_url', async () => {
+    const result = await callTool('decode_url', { text: 'hello%20world' });
+    expect(result.content).toEqual([{ type: 'text', text: 'hello world' }]);
+  });
+
+  test('decode_base64 error returns isError', async () => {
+    const result = await callTool('decode_base64', { text: '!!!invalid!!!' });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/__tests__/encode.test.ts
+++ b/packages/mcp-server/src/__tests__/encode.test.ts
@@ -1,16 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createMcpServer } from '../mcp';
-
-async function callTool(name: string, args: Record<string, unknown>) {
-  const server = createMcpServer();
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  await server.connect(serverTransport);
-  const client = new Client({ name: 'test', version: '1.0.0' });
-  await client.connect(clientTransport);
-  return client.callTool({ name, arguments: args });
-}
+import { callTool } from './test-helpers';
 
 describe('encode tools', () => {
   test('encode_base64', async () => {

--- a/packages/mcp-server/src/__tests__/encode.test.ts
+++ b/packages/mcp-server/src/__tests__/encode.test.ts
@@ -109,4 +109,9 @@ describe('encode tools', () => {
     const result = await callTool('decode_base64', { text: '!!!invalid!!!' });
     expect(result.isError).toBe(true);
   });
+
+  test('decode_url error on malformed percent encoding', async () => {
+    const result = await callTool('decode_url', { text: '%GG' });
+    expect(result.isError).toBe(true);
+  });
 });

--- a/packages/mcp-server/src/__tests__/hash.test.ts
+++ b/packages/mcp-server/src/__tests__/hash.test.ts
@@ -1,16 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createMcpServer } from '../mcp';
-
-async function callTool(name: string, args: Record<string, unknown>) {
-  const server = createMcpServer();
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  await server.connect(serverTransport);
-  const client = new Client({ name: 'test', version: '1.0.0' });
-  await client.connect(clientTransport);
-  return client.callTool({ name, arguments: args });
-}
+import { callTool } from './test-helpers';
 
 describe('hash tools', () => {
   test('hash_md5', async () => {

--- a/packages/mcp-server/src/__tests__/hash.test.ts
+++ b/packages/mcp-server/src/__tests__/hash.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../mcp';
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test', version: '1.0.0' });
+  await client.connect(clientTransport);
+  return client.callTool({ name, arguments: args });
+}
+
+describe('hash tools', () => {
+  test('hash_md5', async () => {
+    const result = await callTool('hash_md5', { text: 'Hello' });
+    expect(result.content).toEqual([{ type: 'text', text: '8b1a9953c4611296a827abf8c47804d7' }]);
+  });
+
+  test('hash_crc32', async () => {
+    const result = await callTool('hash_crc32', { text: 'Hello' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  test('hash_sha1', async () => {
+    const result = await callTool('hash_sha1', { text: 'Hello' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    // SHA-1 produces 40 hex chars
+    expect(text).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test('hash_sha SHA-256', async () => {
+    const result = await callTool('hash_sha', { text: 'Hello', algorithm: 'SHA-256' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    // SHA-256 produces 64 hex chars
+    expect(text).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('hash_sha SHA-384', async () => {
+    const result = await callTool('hash_sha', { text: 'Hello', algorithm: 'SHA-384' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    // SHA-384 produces 96 hex chars
+    expect(text).toMatch(/^[0-9a-f]{96}$/);
+  });
+
+  test('hash_sha SHA-512', async () => {
+    const result = await callTool('hash_sha', { text: 'Hello', algorithm: 'SHA-512' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    // SHA-512 produces 128 hex chars
+    expect(text).toMatch(/^[0-9a-f]{128}$/);
+  });
+
+  test('hash_hmac SHA-256', async () => {
+    const result = await callTool('hash_hmac', {
+      message: 'Hello',
+      secret: 'secret',
+      algorithm: 'SHA-256',
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    // HMAC-SHA256 produces 64 hex chars
+    expect(text).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('hash_hmac SHA-1', async () => {
+    const result = await callTool('hash_hmac', {
+      message: 'Hello',
+      secret: 'key',
+      algorithm: 'SHA-1',
+    });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    // HMAC-SHA1 produces 40 hex chars
+    expect(text).toMatch(/^[0-9a-f]{40}$/);
+  });
+});

--- a/packages/mcp-server/src/__tests__/test-helpers.ts
+++ b/packages/mcp-server/src/__tests__/test-helpers.ts
@@ -1,0 +1,12 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../mcp';
+
+export async function callTool(name: string, args: Record<string, unknown>) {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test', version: '1.0.0' });
+  await client.connect(clientTransport);
+  return client.callTool({ name, arguments: args });
+}

--- a/packages/mcp-server/src/__tests__/text.test.ts
+++ b/packages/mcp-server/src/__tests__/text.test.ts
@@ -1,16 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { createMcpServer } from '../mcp';
-
-async function callTool(name: string, args: Record<string, unknown>) {
-  const server = createMcpServer();
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  await server.connect(serverTransport);
-  const client = new Client({ name: 'test', version: '1.0.0' });
-  await client.connect(clientTransport);
-  return client.callTool({ name, arguments: args });
-}
+import { callTool } from './test-helpers';
 
 describe('text tools', () => {
   test('text_analyze returns all fields', async () => {
@@ -27,7 +16,7 @@ describe('text tools', () => {
   });
 
   test('text_analyze with Japanese', async () => {
-    const result = await callTool('text_analyze', { text: 'こんにちは世界', language: 'ja' });
+    const result = await callTool('text_analyze', { text: '\u3053\u3093\u306b\u3061\u306f\u4e16\u754c', language: 'ja' });
     const stats = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
     expect(stats.charsWithSpaces).toBe(7);
   });

--- a/packages/mcp-server/src/__tests__/text.test.ts
+++ b/packages/mcp-server/src/__tests__/text.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../mcp';
+
+async function callTool(name: string, args: Record<string, unknown>) {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: 'test', version: '1.0.0' });
+  await client.connect(clientTransport);
+  return client.callTool({ name, arguments: args });
+}
+
+describe('text tools', () => {
+  test('text_analyze returns all fields', async () => {
+    const result = await callTool('text_analyze', { text: 'Hello World' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    const stats = JSON.parse(text);
+    expect(stats.charsWithSpaces).toBe(11);
+    expect(stats.charsWithoutSpaces).toBe(10);
+    expect(stats.words).toBe(2);
+    expect(stats.lines).toBe(1);
+    expect(stats.paragraphs).toBe(1);
+    expect(stats).toHaveProperty('bytes');
+    expect(stats).toHaveProperty('readingTimeMinutes');
+  });
+
+  test('text_analyze with Japanese', async () => {
+    const result = await callTool('text_analyze', { text: 'こんにちは世界', language: 'ja' });
+    const stats = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(stats.charsWithSpaces).toBe(7);
+  });
+
+  test('text_deduplicate removes duplicates', async () => {
+    const result = await callTool('text_deduplicate', { text: 'a\nb\na\nc\nb' });
+    expect(result.content).toEqual([{ type: 'text', text: 'a\nb\nc' }]);
+  });
+
+  test('text_deduplicate case insensitive', async () => {
+    const result = await callTool('text_deduplicate', {
+      text: 'Hello\nhello\nHELLO',
+      caseSensitive: false,
+    });
+    expect(result.content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  test('text_deduplicate keeps empty lines by default', async () => {
+    const result = await callTool('text_deduplicate', { text: 'a\n\nb\n\na' });
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain('\n\n');
+  });
+});

--- a/packages/mcp-server/src/empty.ts
+++ b/packages/mcp-server/src/empty.ts
@@ -1,2 +1,8 @@
-export default function noop() {}
+// Stub for raw-body and content-type Node.js modules.
+// MCP SDK imports these but they are not needed in CF Workers
+// when using parsedBody argument in transport.handleRequest().
+// See: https://github.com/mhart/mcp-hono-stateless
+export default function noop() {
+  console.warn('[mcp-server] Stubbed Node.js module called - check fetch-to-node compatibility');
+}
 export const parse = noop;

--- a/packages/mcp-server/src/empty.ts
+++ b/packages/mcp-server/src/empty.ts
@@ -1,0 +1,2 @@
+export default function noop() {}
+export const parse = noop;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,37 @@
+import { Hono } from 'hono';
+import { toReqRes, toFetchResponse } from 'fetch-to-node';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createMcpServer } from './mcp';
+
+const app = new Hono();
+
+const MAX_BODY_SIZE = 1024 * 1024;
+
+app.post('/mcp', async (c) => {
+  const contentLength = Number(c.req.header('content-length') || 0);
+  if (contentLength > MAX_BODY_SIZE) {
+    return c.json({ error: 'Request body too large' }, 413);
+  }
+
+  const server = createMcpServer();
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  await server.connect(transport);
+
+  const body = await c.req.json();
+  const { req, res } = toReqRes(c.req.raw);
+  await transport.handleRequest(req, res, body);
+  return toFetchResponse(res);
+});
+
+app.get('/mcp', async (c) => {
+  c.header('Allow', 'POST');
+  return c.text('SSE not supported in stateless mode', 405);
+});
+
+app.delete('/mcp', async (c) => {
+  return c.json({ ok: true }, 200);
+});
+
+app.get('/health', (c) => c.json({ status: 'ok' }));
+
+export default app;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -13,14 +13,26 @@ app.post('/mcp', async (c) => {
     return c.json({ error: 'Request body too large' }, 413);
   }
 
-  const server = createMcpServer();
-  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-  await server.connect(transport);
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid JSON in request body' }, 400);
+  }
 
-  const body = await c.req.json();
-  const { req, res } = toReqRes(c.req.raw);
-  await transport.handleRequest(req, res, body);
-  return toFetchResponse(res);
+  try {
+    // Stateless mode: create fresh server per request (no session state)
+    const server = createMcpServer();
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await server.connect(transport);
+
+    const { req, res } = toReqRes(c.req.raw);
+    await transport.handleRequest(req, res, body);
+    return toFetchResponse(res);
+  } catch (e) {
+    console.error('[mcp-server] MCP request handling failed:', e);
+    return c.json({ error: 'Internal server error' }, 500);
+  }
 });
 
 app.get('/mcp', async (c) => {
@@ -29,7 +41,9 @@ app.get('/mcp', async (c) => {
 });
 
 app.delete('/mcp', async (c) => {
-  return c.json({ ok: true }, 200);
+  // Stateless mode: no sessions to terminate
+  c.header('Allow', 'POST');
+  return c.text('Session termination not supported in stateless mode', 405);
 });
 
 app.get('/health', (c) => c.json({ status: 'ok' }));

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -23,6 +23,7 @@ app.post('/mcp', async (c) => {
   try {
     // Stateless mode: create fresh server per request (no session state)
     const server = createMcpServer();
+    // @ts-expect-error -- stateless mode requires undefined per MCP SDK docs, but exactOptionalPropertyTypes rejects it
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     await server.connect(transport);
 

--- a/packages/mcp-server/src/mcp.ts
+++ b/packages/mcp-server/src/mcp.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerEncodeTools } from './tools/encode';
 import { registerHashTools } from './tools/hash';
+import { registerCryptoTools } from './tools/crypto';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -10,6 +11,7 @@ export function createMcpServer(): McpServer {
 
   registerEncodeTools(server);
   registerHashTools(server);
+  registerCryptoTools(server);
 
   return server;
 }

--- a/packages/mcp-server/src/mcp.ts
+++ b/packages/mcp-server/src/mcp.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerEncodeTools } from './tools/encode';
+import { registerHashTools } from './tools/hash';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -8,6 +9,7 @@ export function createMcpServer(): McpServer {
   });
 
   registerEncodeTools(server);
+  registerHashTools(server);
 
   return server;
 }

--- a/packages/mcp-server/src/mcp.ts
+++ b/packages/mcp-server/src/mcp.ts
@@ -1,10 +1,13 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerEncodeTools } from './tools/encode';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
     name: 'elchika-tools',
     version: '1.0.0',
   });
+
+  registerEncodeTools(server);
 
   return server;
 }

--- a/packages/mcp-server/src/mcp.ts
+++ b/packages/mcp-server/src/mcp.ts
@@ -1,0 +1,10 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'elchika-tools',
+    version: '1.0.0',
+  });
+
+  return server;
+}

--- a/packages/mcp-server/src/mcp.ts
+++ b/packages/mcp-server/src/mcp.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerEncodeTools } from './tools/encode';
 import { registerHashTools } from './tools/hash';
 import { registerCryptoTools } from './tools/crypto';
+import { registerTextTools } from './tools/text';
 
 export function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -12,6 +13,7 @@ export function createMcpServer(): McpServer {
   registerEncodeTools(server);
   registerHashTools(server);
   registerCryptoTools(server);
+  registerTextTools(server);
 
   return server;
 }

--- a/packages/mcp-server/src/tools/crypto.ts
+++ b/packages/mcp-server/src/tools/crypto.ts
@@ -1,0 +1,277 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  caesarEncrypt,
+  caesarDecrypt,
+  bruteForce,
+} from '../../../../apps/crypto-caesar/src/utils/caesar';
+import { rot13, rot18, rot47 } from '../../../../apps/crypto-rot13/src/utils/rot';
+import {
+  vigenereEncrypt,
+  vigenereDecrypt,
+} from '../../../../apps/crypto-vigenere/src/utils/vigenere';
+import { atbash } from '../../../../apps/crypto-atbash/src/utils/atbash';
+import {
+  affineEncrypt,
+  affineDecrypt,
+  isValidA,
+} from '../../../../apps/crypto-affine/src/utils/affine';
+import {
+  railFenceEncrypt,
+  railFenceDecrypt,
+} from '../../../../apps/crypto-rail-fence/src/utils/railFence';
+import { enigmaEncrypt, DEFAULT_CONFIG } from '../../../../apps/enigma-cipher/src/utils/enigma';
+import type { EnigmaConfig, RotorName } from '../../../../apps/enigma-cipher/src/utils/enigma';
+
+function textResult(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+function errorResult(e: unknown) {
+  return {
+    isError: true,
+    content: [
+      { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+    ],
+  };
+}
+
+export function registerCryptoTools(server: McpServer) {
+  // Caesar encrypt
+  server.tool(
+    'cipher_caesar_encrypt',
+    'Caesar cipher encrypt',
+    {
+      text: z.string().describe('Text to encrypt'),
+      shift: z.number().describe('Shift amount (0-25)'),
+    },
+    async (args) => {
+      try {
+        return textResult(caesarEncrypt(args.text, args.shift));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Caesar decrypt
+  server.tool(
+    'cipher_caesar_decrypt',
+    'Caesar cipher decrypt',
+    {
+      text: z.string().describe('Text to decrypt'),
+      shift: z.number().describe('Shift amount used for encryption'),
+    },
+    async (args) => {
+      try {
+        return textResult(caesarDecrypt(args.text, args.shift));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Caesar brute force
+  server.tool(
+    'cipher_caesar_bruteforce',
+    'Caesar cipher brute force (try all 26 shifts)',
+    {
+      text: z.string().describe('Encrypted text to brute force'),
+    },
+    async (args) => {
+      try {
+        return textResult(JSON.stringify(bruteForce(args.text)));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // ROT
+  server.tool(
+    'cipher_rot',
+    'ROT13/ROT18/ROT47 rotation cipher',
+    {
+      text: z.string().describe('Text to transform'),
+      variant: z.enum(['rot13', 'rot18', 'rot47']).describe('ROT variant'),
+    },
+    async (args) => {
+      try {
+        const fns = { rot13, rot18, rot47 };
+        return textResult(fns[args.variant](args.text));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Vigenere encrypt
+  server.tool(
+    'cipher_vigenere_encrypt',
+    'Vigenere cipher encrypt',
+    {
+      text: z.string().describe('Text to encrypt'),
+      key: z.string().describe('Encryption key (alphabetic)'),
+    },
+    async (args) => {
+      try {
+        return textResult(vigenereEncrypt(args.text, args.key));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Vigenere decrypt
+  server.tool(
+    'cipher_vigenere_decrypt',
+    'Vigenere cipher decrypt',
+    {
+      text: z.string().describe('Text to decrypt'),
+      key: z.string().describe('Decryption key (alphabetic)'),
+    },
+    async (args) => {
+      try {
+        return textResult(vigenereDecrypt(args.text, args.key));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Atbash
+  server.tool(
+    'cipher_atbash',
+    'Atbash cipher (symmetric: A<->Z, B<->Y, ...)',
+    {
+      text: z.string().describe('Text to transform'),
+    },
+    async (args) => {
+      try {
+        return textResult(atbash(args.text));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Affine encrypt
+  server.tool(
+    'cipher_affine_encrypt',
+    'Affine cipher encrypt (E(x) = (a*x + b) mod 26)',
+    {
+      text: z.string().describe('Text to encrypt'),
+      a: z.number().describe('Multiplier (must be coprime with 26)'),
+      b: z.number().describe('Shift value'),
+    },
+    async (args) => {
+      try {
+        if (!isValidA(args.a)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: "a" must be coprime with 26. Valid values: 1,3,5,7,9,11,15,17,19,21,23,25',
+              },
+            ],
+          };
+        }
+        return textResult(affineEncrypt(args.text, args.a, args.b));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Affine decrypt
+  server.tool(
+    'cipher_affine_decrypt',
+    'Affine cipher decrypt',
+    {
+      text: z.string().describe('Text to decrypt'),
+      a: z.number().describe('Multiplier used for encryption'),
+      b: z.number().describe('Shift value used for encryption'),
+    },
+    async (args) => {
+      try {
+        if (!isValidA(args.a)) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: "a" must be coprime with 26. Valid values: 1,3,5,7,9,11,15,17,19,21,23,25',
+              },
+            ],
+          };
+        }
+        return textResult(affineDecrypt(args.text, args.a, args.b));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Rail Fence encrypt
+  server.tool(
+    'cipher_rail_fence_encrypt',
+    'Rail fence cipher encrypt',
+    {
+      text: z.string().describe('Text to encrypt'),
+      rails: z.number().min(2).describe('Number of rails (minimum 2)'),
+    },
+    async (args) => {
+      try {
+        return textResult(railFenceEncrypt(args.text, args.rails));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Rail Fence decrypt
+  server.tool(
+    'cipher_rail_fence_decrypt',
+    'Rail fence cipher decrypt',
+    {
+      text: z.string().describe('Text to decrypt'),
+      rails: z.number().min(2).describe('Number of rails used for encryption'),
+    },
+    async (args) => {
+      try {
+        return textResult(railFenceDecrypt(args.text, args.rails));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+
+  // Enigma
+  server.tool(
+    'cipher_enigma',
+    'Enigma machine cipher (symmetric encryption)',
+    {
+      text: z.string().describe('Text to encrypt/decrypt (uppercase letters)'),
+      rotors: z
+        .tuple([z.enum(['I', 'II', 'III']), z.enum(['I', 'II', 'III']), z.enum(['I', 'II', 'III'])])
+        .optional()
+        .describe('Rotor selection [left, middle, right] (default: I, II, III)'),
+      positions: z
+        .tuple([z.number(), z.number(), z.number()])
+        .optional()
+        .describe('Initial rotor positions [left, middle, right] (default: 0, 0, 0)'),
+    },
+    async (args) => {
+      try {
+        const config: EnigmaConfig = {
+          rotors: (args.rotors as [RotorName, RotorName, RotorName]) ?? DEFAULT_CONFIG.rotors,
+          positions: (args.positions as [number, number, number]) ?? DEFAULT_CONFIG.positions,
+        };
+        return textResult(enigmaEncrypt(args.text, config));
+      } catch (e) {
+        return errorResult(e);
+      }
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/crypto.ts
+++ b/packages/mcp-server/src/tools/crypto.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { textResult, errorResult } from './helpers';
 import {
   caesarEncrypt,
   caesarDecrypt,
@@ -23,19 +24,6 @@ import {
 import { enigmaEncrypt, DEFAULT_CONFIG } from '../../../../apps/enigma-cipher/src/utils/enigma';
 import type { EnigmaConfig, RotorName } from '../../../../apps/enigma-cipher/src/utils/enigma';
 
-function textResult(text: string) {
-  return { content: [{ type: 'text' as const, text }] };
-}
-
-function errorResult(e: unknown) {
-  return {
-    isError: true,
-    content: [
-      { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-    ],
-  };
-}
-
 export function registerCryptoTools(server: McpServer) {
   // Caesar encrypt
   server.tool(
@@ -49,7 +37,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(caesarEncrypt(args.text, args.shift));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_caesar_encrypt', e);
       }
     },
   );
@@ -66,7 +54,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(caesarDecrypt(args.text, args.shift));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_caesar_decrypt', e);
       }
     },
   );
@@ -82,7 +70,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(JSON.stringify(bruteForce(args.text), null, 2));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_caesar_bruteforce', e);
       }
     },
   );
@@ -100,7 +88,7 @@ export function registerCryptoTools(server: McpServer) {
         const fns = { rot13, rot18, rot47 };
         return textResult(fns[args.variant](args.text));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_rot', e);
       }
     },
   );
@@ -117,7 +105,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(vigenereEncrypt(args.text, args.key));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_vigenere_encrypt', e);
       }
     },
   );
@@ -134,7 +122,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(vigenereDecrypt(args.text, args.key));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_vigenere_decrypt', e);
       }
     },
   );
@@ -150,7 +138,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(atbash(args.text));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_atbash', e);
       }
     },
   );
@@ -179,7 +167,7 @@ export function registerCryptoTools(server: McpServer) {
         }
         return textResult(affineEncrypt(args.text, args.a, args.b));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_affine_encrypt', e);
       }
     },
   );
@@ -208,7 +196,7 @@ export function registerCryptoTools(server: McpServer) {
         }
         return textResult(affineDecrypt(args.text, args.a, args.b));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_affine_decrypt', e);
       }
     },
   );
@@ -225,7 +213,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(railFenceEncrypt(args.text, args.rails));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_rail_fence_encrypt', e);
       }
     },
   );
@@ -242,7 +230,7 @@ export function registerCryptoTools(server: McpServer) {
       try {
         return textResult(railFenceDecrypt(args.text, args.rails));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_rail_fence_decrypt', e);
       }
     },
   );
@@ -270,7 +258,7 @@ export function registerCryptoTools(server: McpServer) {
         };
         return textResult(enigmaEncrypt(args.text, config));
       } catch (e) {
-        return errorResult(e);
+        return errorResult('cipher_enigma', e);
       }
     },
   );

--- a/packages/mcp-server/src/tools/crypto.ts
+++ b/packages/mcp-server/src/tools/crypto.ts
@@ -80,7 +80,7 @@ export function registerCryptoTools(server: McpServer) {
     },
     async (args) => {
       try {
-        return textResult(JSON.stringify(bruteForce(args.text)));
+        return textResult(JSON.stringify(bruteForce(args.text), null, 2));
       } catch (e) {
         return errorResult(e);
       }

--- a/packages/mcp-server/src/tools/encode.ts
+++ b/packages/mcp-server/src/tools/encode.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { textResult, errorResult } from './helpers';
 import { encodeBase64, decodeBase64 } from '../../../../apps/encode-base64-string/src/utils/base64';
 import { encodeBase32, decodeBase32 } from '../../../../apps/encode-base32/src/utils/base32';
 import {
@@ -34,14 +35,9 @@ function textTool(
 ) {
   server.tool(name, description, { [inputName]: z.string().describe(inputDesc) }, async (args) => {
     try {
-      return { content: [{ type: 'text' as const, text: fn(args[inputName] as string) }] };
+      return textResult(fn(args[inputName] as string));
     } catch (e) {
-      return {
-        isError: true,
-        content: [
-          { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-        ],
-      };
+      return errorResult(name, e);
     }
   });
 }

--- a/packages/mcp-server/src/tools/encode.ts
+++ b/packages/mcp-server/src/tools/encode.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { encodeBase64, decodeBase64 } from '../../../../apps/encode-base64-string/src/utils/base64';
+import { encodeBase32, decodeBase32 } from '../../../../apps/encode-base32/src/utils/base32';
+import {
+  textToBinary,
+  binaryToText,
+  textToHex,
+  hexToText,
+  textToDecimal,
+  decimalToText,
+} from '../../../../apps/encode-binary/src/utils/binary';
+import {
+  encodeHTMLEntities,
+  decodeHTMLEntities,
+} from '../../../../apps/encode-html-entity/src/utils/htmlEntity';
+import { textToMorse, morseToText } from '../../../../apps/encode-morse/src/utils/morse';
+import {
+  domainToASCII,
+  domainFromASCII,
+} from '../../../../apps/encode-punycode/src/utils/punycode';
+import {
+  textToUnicodeEscape,
+  unicodeEscapeToText,
+} from '../../../../apps/encode-unicode/src/utils/unicode';
+
+function textTool(
+  server: McpServer,
+  name: string,
+  description: string,
+  inputName: string,
+  inputDesc: string,
+  fn: (input: string) => string,
+) {
+  server.tool(name, description, { [inputName]: z.string().describe(inputDesc) }, async (args) => {
+    try {
+      return { content: [{ type: 'text' as const, text: fn(args[inputName] as string) }] };
+    } catch (e) {
+      return {
+        isError: true,
+        content: [
+          { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+        ],
+      };
+    }
+  });
+}
+
+export function registerEncodeTools(server: McpServer) {
+  // Base64
+  textTool(server, 'encode_base64', 'Base64 encode', 'text', 'Text to encode', (t) =>
+    encodeBase64(t),
+  );
+  textTool(server, 'decode_base64', 'Base64 decode', 'text', 'Base64 string to decode', (t) =>
+    decodeBase64(t),
+  );
+
+  // Base32
+  textTool(server, 'encode_base32', 'Base32 encode', 'text', 'Text to encode', (t) =>
+    encodeBase32(t),
+  );
+  textTool(server, 'decode_base32', 'Base32 decode', 'text', 'Base32 string to decode', (t) =>
+    decodeBase32(t),
+  );
+
+  // Binary
+  textTool(server, 'encode_binary', 'Text to binary', 'text', 'Text to convert', (t) =>
+    textToBinary(t),
+  );
+  textTool(server, 'decode_binary', 'Binary to text', 'text', 'Binary string', (t) =>
+    binaryToText(t),
+  );
+
+  // Hex
+  textTool(server, 'encode_hex', 'Text to hex', 'text', 'Text to convert', (t) => textToHex(t));
+  textTool(server, 'decode_hex', 'Hex to text', 'text', 'Hex string', (t) => hexToText(t));
+
+  // Decimal
+  textTool(
+    server,
+    'encode_decimal',
+    'Text to decimal code points',
+    'text',
+    'Text to convert',
+    (t) => textToDecimal(t),
+  );
+  textTool(
+    server,
+    'decode_decimal',
+    'Decimal code points to text',
+    'text',
+    'Space-separated decimals',
+    (t) => decimalToText(t),
+  );
+
+  // HTML Entity
+  textTool(
+    server,
+    'encode_html_entity',
+    'Encode HTML special chars',
+    'text',
+    'Text with HTML chars',
+    (t) => encodeHTMLEntities(t),
+  );
+  textTool(
+    server,
+    'decode_html_entity',
+    'Decode HTML entities',
+    'text',
+    'Text with HTML entities',
+    (t) => decodeHTMLEntities(t),
+  );
+
+  // Morse
+  textTool(server, 'encode_morse', 'Text to Morse code', 'text', 'Text to convert', (t) =>
+    textToMorse(t),
+  );
+  textTool(server, 'decode_morse', 'Morse code to text', 'text', 'Morse code string', (t) =>
+    morseToText(t),
+  );
+
+  // Punycode
+  textTool(
+    server,
+    'encode_punycode',
+    'Domain to ASCII (Punycode)',
+    'domain',
+    'Domain name',
+    (d) => domainToASCII(d),
+  );
+  textTool(
+    server,
+    'decode_punycode',
+    'ASCII domain to Unicode',
+    'domain',
+    'ASCII domain',
+    (d) => domainFromASCII(d),
+  );
+
+  // Unicode escape
+  textTool(
+    server,
+    'encode_unicode_escape',
+    'Text to Unicode escape',
+    'text',
+    'Text to escape',
+    (t) => textToUnicodeEscape(t),
+  );
+  textTool(
+    server,
+    'decode_unicode_escape',
+    'Unicode escape to text',
+    'text',
+    'Unicode escape string',
+    (t) => unicodeEscapeToText(t),
+  );
+
+  // URL
+  textTool(server, 'encode_url', 'URL encode', 'text', 'Text to encode', (t) =>
+    encodeURIComponent(t),
+  );
+  textTool(server, 'decode_url', 'URL decode', 'text', 'URL encoded string', (t) =>
+    decodeURIComponent(t),
+  );
+}

--- a/packages/mcp-server/src/tools/hash.ts
+++ b/packages/mcp-server/src/tools/hash.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { textResult, errorResult } from './helpers';
 import { md5 } from '../../../../apps/hash-md5/src/utils/md5';
 import { crc32 } from '../../../../apps/hash-crc32/src/utils/crc32';
 import { generateSHA1 } from '../../../../apps/hash-sha1/src/utils/sha1';
@@ -16,14 +17,9 @@ export function registerHashTools(server: McpServer) {
     { text: z.string().describe('Text to hash') },
     async (args) => {
       try {
-        return { content: [{ type: 'text' as const, text: md5(args.text) }] };
+        return textResult(md5(args.text));
       } catch (e) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-          ],
-        };
+        return errorResult('hash_md5', e);
       }
     },
   );
@@ -35,14 +31,9 @@ export function registerHashTools(server: McpServer) {
     { text: z.string().describe('Text to hash') },
     async (args) => {
       try {
-        return { content: [{ type: 'text' as const, text: crc32(args.text) }] };
+        return textResult(crc32(args.text));
       } catch (e) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-          ],
-        };
+        return errorResult('hash_crc32', e);
       }
     },
   );
@@ -55,14 +46,9 @@ export function registerHashTools(server: McpServer) {
     async (args) => {
       try {
         const hash = await generateSHA1(args.text);
-        return { content: [{ type: 'text' as const, text: hash }] };
+        return textResult(hash);
       } catch (e) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-          ],
-        };
+        return errorResult('hash_sha1', e);
       }
     },
   );
@@ -80,14 +66,9 @@ export function registerHashTools(server: McpServer) {
     async (args) => {
       try {
         const hash = await generateSHA(args.text, args.algorithm as HashAlgorithm);
-        return { content: [{ type: 'text' as const, text: hash }] };
+        return textResult(hash);
       } catch (e) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-          ],
-        };
+        return errorResult('hash_sha', e);
       }
     },
   );
@@ -110,14 +91,9 @@ export function registerHashTools(server: McpServer) {
           args.secret,
           args.algorithm as HmacAlgorithm,
         );
-        return { content: [{ type: 'text' as const, text: hmac }] };
+        return textResult(hmac);
       } catch (e) {
-        return {
-          isError: true,
-          content: [
-            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
-          ],
-        };
+        return errorResult('hash_hmac', e);
       }
     },
   );

--- a/packages/mcp-server/src/tools/hash.ts
+++ b/packages/mcp-server/src/tools/hash.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { md5 } from '../../../../apps/hash-md5/src/utils/md5';
+import { crc32 } from '../../../../apps/hash-crc32/src/utils/crc32';
+import { generateSHA1 } from '../../../../apps/hash-sha1/src/utils/sha1';
+import { generateSHA } from '../../../../apps/hash-sha256/src/utils/sha';
+import type { HashAlgorithm } from '../../../../apps/hash-sha256/src/utils/sha';
+import { generateHMAC } from '../../../../apps/hash-hmac/src/utils/hmac';
+import type { HmacAlgorithm } from '../../../../apps/hash-hmac/src/utils/hmac';
+
+export function registerHashTools(server: McpServer) {
+  // MD5
+  server.tool(
+    'hash_md5',
+    'Compute MD5 hash',
+    { text: z.string().describe('Text to hash') },
+    async (args) => {
+      try {
+        return { content: [{ type: 'text' as const, text: md5(args.text) }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+          ],
+        };
+      }
+    },
+  );
+
+  // CRC32
+  server.tool(
+    'hash_crc32',
+    'Compute CRC32 checksum',
+    { text: z.string().describe('Text to hash') },
+    async (args) => {
+      try {
+        return { content: [{ type: 'text' as const, text: crc32(args.text) }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+          ],
+        };
+      }
+    },
+  );
+
+  // SHA-1
+  server.tool(
+    'hash_sha1',
+    'Compute SHA-1 hash',
+    { text: z.string().describe('Text to hash') },
+    async (args) => {
+      try {
+        const hash = await generateSHA1(args.text);
+        return { content: [{ type: 'text' as const, text: hash }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+          ],
+        };
+      }
+    },
+  );
+
+  // SHA-256/384/512
+  server.tool(
+    'hash_sha',
+    'Compute SHA-256/384/512 hash',
+    {
+      text: z.string().describe('Text to hash'),
+      algorithm: z
+        .enum(['SHA-256', 'SHA-384', 'SHA-512'])
+        .describe('Hash algorithm'),
+    },
+    async (args) => {
+      try {
+        const hash = await generateSHA(args.text, args.algorithm as HashAlgorithm);
+        return { content: [{ type: 'text' as const, text: hash }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+          ],
+        };
+      }
+    },
+  );
+
+  // HMAC
+  server.tool(
+    'hash_hmac',
+    'Compute HMAC authentication code',
+    {
+      message: z.string().describe('Message to authenticate'),
+      secret: z.string().describe('Secret key'),
+      algorithm: z
+        .enum(['SHA-256', 'SHA-384', 'SHA-512', 'SHA-1'])
+        .describe('HMAC algorithm'),
+    },
+    async (args) => {
+      try {
+        const hmac = await generateHMAC(
+          args.message,
+          args.secret,
+          args.algorithm as HmacAlgorithm,
+        );
+        return { content: [{ type: 'text' as const, text: hmac }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [
+            { type: 'text' as const, text: `Error: ${e instanceof Error ? e.message : String(e)}` },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/helpers.ts
+++ b/packages/mcp-server/src/tools/helpers.ts
@@ -1,0 +1,16 @@
+export function textResult(text: string) {
+  return { content: [{ type: 'text' as const, text }] };
+}
+
+export function errorResult(toolName: string, e: unknown) {
+  console.error(`[mcp-server] Tool "${toolName}" failed:`, e);
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text' as const,
+        text: `Error in ${toolName}: ${e instanceof Error ? e.message : String(e)}`,
+      },
+    ],
+  };
+}

--- a/packages/mcp-server/src/tools/text.ts
+++ b/packages/mcp-server/src/tools/text.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { textResult, errorResult } from './helpers';
 
 // --- Types (inlined from apps/text-counter/src/types/index.ts) ---
 type Language = 'ja' | 'en' | 'unknown';
@@ -111,12 +112,9 @@ export function registerTextTools(server: McpServer) {
     async ({ text, language }) => {
       try {
         const stats = analyzeTextLocal(text, language ?? 'auto');
-        return { content: [{ type: 'text', text: JSON.stringify(stats, null, 2) }] };
+        return textResult(JSON.stringify(stats, null, 2));
       } catch (e) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
-        };
+        return errorResult('text_analyze', e);
       }
     },
   );
@@ -137,12 +135,9 @@ export function registerTextTools(server: McpServer) {
           trimWhitespace: trimWhitespace ?? false,
           keepEmptyLines: keepEmptyLines ?? true,
         });
-        return { content: [{ type: 'text', text: result }] };
+        return textResult(result);
       } catch (e) {
-        return {
-          isError: true,
-          content: [{ type: 'text', text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
-        };
+        return errorResult('text_deduplicate', e);
       }
     },
   );

--- a/packages/mcp-server/src/tools/text.ts
+++ b/packages/mcp-server/src/tools/text.ts
@@ -38,7 +38,7 @@ function countParagraphs(text: string): number {
 }
 
 function calculateBytes(text: string): number {
-  return new Blob([text]).size;
+  return new TextEncoder().encode(text).byteLength;
 }
 
 function analyzeTextLocal(text: string, language: 'ja' | 'en' | 'auto' = 'auto'): TextStats {

--- a/packages/mcp-server/src/tools/text.ts
+++ b/packages/mcp-server/src/tools/text.ts
@@ -1,0 +1,149 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// --- Types (inlined from apps/text-counter/src/types/index.ts) ---
+type Language = 'ja' | 'en' | 'unknown';
+
+interface TextStats {
+  charsWithSpaces: number;
+  charsWithoutSpaces: number;
+  words: number;
+  lines: number;
+  paragraphs: number;
+  bytes: number;
+  readingTimeMinutes: number;
+}
+
+// --- Constants (inlined from apps/text-counter/src/config/constants.ts) ---
+const READING_SPEED = { ja: 500, en: 225 } as const;
+
+// --- analyzeText logic (from apps/text-counter/src/utils/textAnalysis.ts) ---
+function detectLanguage(text: string): Language {
+  if (!text.trim()) return 'unknown';
+  const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/;
+  return japanesePattern.test(text) ? 'ja' : 'en';
+}
+
+function countWords(text: string, language: Language): number {
+  if (!text.trim()) return 0;
+  if (language === 'ja') {
+    return text.split(/[\s、。！？]/g).filter((w) => w.trim().length > 0).length;
+  }
+  return text.split(/\s+/).filter((w) => w.trim().length > 0).length;
+}
+
+function countParagraphs(text: string): number {
+  if (!text.trim()) return 0;
+  return text.split(/\n\n+/).filter((p) => p.trim().length > 0).length;
+}
+
+function calculateBytes(text: string): number {
+  return new Blob([text]).size;
+}
+
+function analyzeTextLocal(text: string, language: 'ja' | 'en' | 'auto' = 'auto'): TextStats {
+  const detectedLanguage = detectLanguage(text);
+  const lang: Language = language === 'auto' ? detectedLanguage : language;
+
+  const charsWithSpaces = text.length;
+  const charsWithoutSpaces = text.replace(/\s/g, '').length;
+  const lines = text.split('\n').length;
+  const words = countWords(text, lang);
+  const paragraphs = countParagraphs(text);
+  const bytes = calculateBytes(text);
+
+  const readingTimeMinutes =
+    lang === 'ja'
+      ? Math.ceil(charsWithoutSpaces / READING_SPEED.ja)
+      : Math.ceil(words / READING_SPEED.en);
+
+  return { charsWithSpaces, charsWithoutSpaces, words, lines, paragraphs, bytes, readingTimeMinutes };
+}
+
+// --- deduplicateLines logic (from apps/text-deduplicate/src/utils/deduplicate.ts) ---
+interface DeduplicateSettings {
+  caseSensitive: boolean;
+  trimWhitespace: boolean;
+  keepEmptyLines: boolean;
+}
+
+function deduplicateLinesLocal(text: string, settings: DeduplicateSettings): string {
+  if (!text) return '';
+
+  const lines = text.split('\n');
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const line of lines) {
+    let processedLine = line;
+
+    if (settings.trimWhitespace) {
+      processedLine = processedLine.trim();
+    }
+
+    if (processedLine === '') {
+      if (settings.keepEmptyLines) {
+        result.push(line);
+      }
+      continue;
+    }
+
+    const key = settings.caseSensitive ? processedLine : processedLine.toLowerCase();
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(line);
+    }
+  }
+
+  return result.join('\n');
+}
+
+// --- MCP Tool Registration ---
+export function registerTextTools(server: McpServer) {
+  server.tool(
+    'text_analyze',
+    'Analyze text statistics (chars, words, lines, paragraphs, bytes, reading time)',
+    {
+      text: z.string().describe('Text to analyze'),
+      language: z.enum(['ja', 'en', 'auto']).optional().describe('Language (default: auto-detect)'),
+    },
+    async ({ text, language }) => {
+      try {
+        const stats = analyzeTextLocal(text, language ?? 'auto');
+        return { content: [{ type: 'text', text: JSON.stringify(stats, null, 2) }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'text_deduplicate',
+    'Remove duplicate lines from text',
+    {
+      text: z.string().describe('Text with potential duplicate lines'),
+      caseSensitive: z.boolean().optional().describe('Case sensitive comparison (default: true)'),
+      trimWhitespace: z.boolean().optional().describe('Trim whitespace before comparing (default: false)'),
+      keepEmptyLines: z.boolean().optional().describe('Keep empty lines (default: true)'),
+    },
+    async ({ text, caseSensitive, trimWhitespace, keepEmptyLines }) => {
+      try {
+        const result = deduplicateLinesLocal(text, {
+          caseSensitive: caseSensitive ?? true,
+          trimWhitespace: trimWhitespace ?? false,
+          keepEmptyLines: keepEmptyLines ?? true,
+        });
+        return { content: [{ type: 'text', text: result }] };
+      } catch (e) {
+        return {
+          isError: true,
+          content: [{ type: 'text', text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+        };
+      }
+    },
+  );
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]
+}

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/__tests__/**/*.test.ts'],
+  },
+});

--- a/packages/mcp-server/wrangler.toml
+++ b/packages/mcp-server/wrangler.toml
@@ -1,0 +1,12 @@
+name = "tools-mcp-server"
+main = "src/index.ts"
+compatibility_date = "2025-04-22"
+compatibility_flags = ["nodejs_compat"]
+
+[alias]
+"raw-body" = "./src/empty.ts"
+"content-type" = "./src/empty.ts"
+
+[[routes]]
+pattern = "mcp.tools.elchika.app"
+custom_domain = true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 10.2.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^10.2.19
-        version: 10.2.19(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
+        version: 10.2.19(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -8725,6 +8725,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
+      happy-dom:
+        specifier: ^20.0.10
+        version: 20.8.4
       postcss:
         specifier: ^8.5.6
         version: 8.5.8
@@ -19871,6 +19874,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.27(postcss@8.5.8)
+      happy-dom:
+        specifier: ^20.0.10
+        version: 20.8.4
       postcss:
         specifier: ^8.5.6
         version: 8.5.8
@@ -20249,6 +20255,31 @@ importers:
       vite:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7)
+
+  packages/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.27.1(zod@3.25.76)
+      fetch-to-node:
+        specifier: ^2.1.0
+        version: 2.1.0
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.8
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20241205.0
+        version: 4.20260317.1
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@1.21.7)(lightningcss@1.32.0)
+      wrangler:
+        specifier: ^4.0.0
+        version: 4.74.0(@cloudflare/workers-types@4.20260317.1)
 
   packages/router:
     dependencies:
@@ -20732,6 +20763,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
@@ -20915,6 +20952,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/canvas-android-arm64@0.1.97':
     resolution: {integrity: sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==}
@@ -21759,6 +21806,144 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -22051,8 +22236,25 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
@@ -22183,10 +22385,25 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -22268,6 +22485,10 @@ packages:
   bmp-js@0.1.0:
     resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
@@ -22288,9 +22509,21 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -22343,8 +22576,24 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -22352,6 +22601,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -22408,6 +22661,10 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -22442,6 +22699,13 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
 
@@ -22451,6 +22715,10 @@ packages:
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -22462,8 +22730,20 @@ packages:
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -22479,6 +22759,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -22487,17 +22770,52 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -22511,16 +22829,31 @@ packages:
       picomatch:
         optional: true
 
+  fetch-to-node@2.1.0:
+    resolution: {integrity: sha512-Wq05j6LE1GrWpT2t1YbCkyFY6xKRJq3hx/oRJdWEJpZlik3g25MmdJS6RFm49iiMJw6zpZuBOrgihOgy2jGyAA==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -22546,9 +22879,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -22565,9 +22906,17 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   happy-dom@20.8.4:
     resolution: {integrity: sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ==}
     engines: {node: '>=20.0.0'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -22576,6 +22925,14 @@ packages:
   hono@4.12.8:
     resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.2:
     resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
@@ -22595,6 +22952,14 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -22633,6 +22998,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
@@ -22650,8 +23018,14 @@ packages:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   jsbarcode@3.12.3:
     resolution: {integrity: sha512-CuHU9hC6dPsHF5oVFMo8NW76uQVjH4L22CsP4hW+dNnGywJHC/B0ThA1CTDVLnxKLrrpYdicBLnd2xsgTfRnvg==}
@@ -22660,6 +23034,12 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -22786,6 +23166,18 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -22793,6 +23185,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -22839,6 +23239,10 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
     engines: {node: '>=10'}
@@ -22870,8 +23274,16 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -22918,6 +23330,10 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -22935,6 +23351,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -22972,6 +23391,10 @@ packages:
   pixelmatch@7.1.0:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
@@ -23051,6 +23474,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -23059,8 +23486,20 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -23151,6 +23590,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -23168,6 +23611,15 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -23181,6 +23633,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -23193,11 +23648,22 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -23210,6 +23676,25 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -23228,6 +23713,16 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -23270,6 +23765,9 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -23323,6 +23821,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -23330,6 +23831,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
@@ -23346,6 +23851,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -23374,6 +23883,10 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -23388,6 +23901,10 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -23427,10 +23944,59 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-plus@0.1.12:
     resolution: {integrity: sha512-8s1RzomZkgrJRiwiYWGq3R0txFPYfBBJGp73XNHQnme0KTTVH5dNm/E2GNyBSMFJbeeF7eh1OSgqWVc2FpR6eA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@8.0.0:
     resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
@@ -23475,6 +24041,34 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wasm-feature-detect@1.8.0:
     resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
 
@@ -23497,6 +24091,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   workerd@1.20260312.1:
@@ -23571,6 +24170,14 @@ packages:
 
   zlibjs@0.3.1:
     resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -23898,6 +24505,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@iarna/toml@2.2.5': {}
 
   '@img/colour@1.1.0': {}
@@ -24027,6 +24638,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.8)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.8
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/canvas-android-arm64@0.1.97':
     optional: true
@@ -24615,11 +25248,88 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.9': {}
 
-  '@rollup/pluginutils@5.3.0':
+  '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.59.0
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
 
   '@sindresorhus/is@7.2.0': {}
 
@@ -24633,9 +25343,9 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/builder-vite@10.2.19(esbuild@0.27.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))':
+  '@storybook/builder-vite@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
+      '@storybook/csf-plugin': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
       storybook: 10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7)
@@ -24644,12 +25354,13 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.19(esbuild@0.27.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))':
+  '@storybook/csf-plugin@10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))':
     dependencies:
       storybook: 10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.4
+      rollup: 4.59.0
       vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7)
 
   '@storybook/global@5.0.0': {}
@@ -24665,11 +25376,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.2.19(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))':
+  '@storybook/react-vite@10.2.19(esbuild@0.27.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
-      '@rollup/pluginutils': 5.3.0
-      '@storybook/builder-vite': 10.2.19(esbuild@0.27.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      '@storybook/builder-vite': 10.2.19(esbuild@0.27.4)(rollup@4.59.0)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
       '@storybook/react': 10.2.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.2.19(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -24902,9 +25613,29 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
     dependencies:
@@ -24987,7 +25718,23 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.12':
     optional: true
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -25053,6 +25800,20 @@ snapshots:
 
   bmp-js@0.1.0: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -25078,7 +25839,19 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase-css@2.0.1: {}
 
@@ -25135,11 +25908,24 @@ snapshots:
 
   commander@4.1.1: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -25178,6 +25964,8 @@ snapshots:
 
   define-lazy-prop@3.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -25200,11 +25988,21 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.313: {}
 
   emoji-regex@8.0.0: {}
 
   empathic@2.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -25214,7 +26012,15 @@ snapshots:
 
   error-stack-parser-es@1.0.5: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -25276,13 +26082,69 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   esprima@4.0.1: {}
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -25292,6 +26154,8 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-uri@3.1.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -25300,16 +26164,33 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-to-node@2.1.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -25325,7 +26206,25 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   github-from-package@0.0.0: {}
 
@@ -25343,6 +26242,8 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  gopd@1.2.0: {}
+
   happy-dom@20.8.4:
     dependencies:
       '@types/node': 25.5.0
@@ -25355,11 +26256,25 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  has-symbols@1.1.0: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
   hono@4.12.8: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   idb-keyval@6.2.2: {}
 
@@ -25372,6 +26287,10 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -25399,6 +26318,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-url@1.2.4: {}
 
   is-wsl@3.1.1:
@@ -25411,11 +26332,19 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   jsbarcode@3.12.3: {}
 
   jsesc@3.1.0: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -25509,12 +26438,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-response@3.1.0: {}
 
@@ -25556,6 +26497,8 @@ snapshots:
 
   napi-build-utils@2.0.0: {}
 
+  negotiator@1.0.0: {}
+
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
@@ -25574,7 +26517,13 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -25657,6 +26606,8 @@ snapshots:
 
   pako@1.0.11: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -25669,6 +26620,8 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -25698,6 +26651,8 @@ snapshots:
   pixelmatch@7.1.0:
     dependencies:
       pngjs: 7.0.0
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.58.2: {}
 
@@ -25771,6 +26726,11 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -25782,7 +26742,20 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -25891,6 +26864,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-main-filename@2.0.0: {}
 
   resolve@1.22.11:
@@ -25922,6 +26897,47 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
 
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -25932,15 +26948,44 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safer-buffer@2.1.2: {}
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-blocking@2.0.0: {}
 
   setimmediate@1.0.5: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -25979,6 +27024,36 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -25996,6 +27071,12 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.6.1: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   std-env@4.0.0: {}
 
@@ -26047,6 +27128,10 @@ snapshots:
   strip-indent@4.1.1: {}
 
   strip-json-comments@2.0.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   sucrase@3.35.1:
     dependencies:
@@ -26140,12 +27225,16 @@ snapshots:
 
   tinybench@2.9.0: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
 
   tinypool@2.1.0: {}
 
@@ -26156,6 +27245,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toidentifier@1.0.1: {}
 
   totalist@3.0.1: {}
 
@@ -26179,6 +27270,12 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@7.18.2: {}
@@ -26188,6 +27285,8 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unpipe@1.0.0: {}
 
   unplugin@2.3.11:
     dependencies:
@@ -26222,6 +27321,29 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-plus@0.1.12(@types/node@25.5.0)(esbuild@0.27.4)(happy-dom@20.8.4)(jiti@1.21.7)(typescript@5.9.3)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7)):
     dependencies:
@@ -26269,6 +27391,20 @@ snapshots:
       - vite
       - yaml
 
+  vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      lightningcss: 1.32.0
+
   vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7):
     dependencies:
       '@oxc-project/runtime': 0.115.0
@@ -26282,6 +27418,48 @@ snapshots:
       esbuild: 0.27.4
       fsevents: 2.3.3
       jiti: 1.21.7
+
+  vitest@3.2.4(@types/node@25.5.0)(happy-dom@20.8.4)(jiti@1.21.7)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@25.5.0)(jiti@1.21.7)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+      happy-dom: 20.8.4
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   wasm-feature-detect@1.8.0: {}
 
@@ -26301,6 +27479,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   workerd@1.20260312.1:
     optionalDependencies:
@@ -26380,3 +27563,9 @@ snapshots:
       youch-core: 0.3.3
 
   zlibjs@0.3.1: {}
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary

- Elchika Tools のテキスト系ツール 39 個を MCP (Model Context Protocol) サーバーとして公開する `packages/mcp-server/` パッケージを新規追加
- Cloudflare Workers (Hono + Streamable HTTP) にデプロイ可能
- 既存 `apps/*/src/utils/` の純粋関数を直接 import して MCP Tool として登録

## Tools (39)

| Category | Count | Examples |
|----------|-------|---------|
| Encode | 20 | base64, base32, binary, hex, decimal, html_entity, morse, punycode, unicode_escape, url |
| Hash | 5 | md5, crc32, sha1, sha (256/384/512), hmac |
| Crypto | 12 | caesar, rot13/18/47, vigenere, atbash, affine, rail_fence, enigma |
| Text | 2 | text_analyze, text_deduplicate |

## Architecture

```
MCP Client (Claude Code, etc.)
  -> POST /mcp (Streamable HTTP)
    -> Hono Router (CF Workers)
      -> McpServer (tool dispatch)
        -> apps/*/src/utils/ pure functions
```

- `fetch-to-node` で Fetch API -> Node.js req/res 変換 (CF Workers 互換)
- `raw-body`/`content-type` を wrangler alias で空モジュールに差し替え

## Test plan

- [x] 47 unit/integration tests (vitest) - ALL PASS
- [ ] `wrangler dev` でローカル動作確認
- [ ] `wrangler deploy` で本番デプロイ
- [ ] Claude Code MCP 設定で接続確認

## Related

- Design spec: `.docs/plans/mcp-server-design.md`
- Implementation plan: `.docs/plans/mcp-server-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)