### PR TITLE
feat: add Markdown to PDF tool

### DIFF
--- a/.docs/plans/markdown-to-pdf-design.md
+++ b/.docs/plans/markdown-to-pdf-design.md
@@ -1,0 +1,214 @@
+# Markdown to PDF — Design Spec
+
+**Goal:** ブラウザ上でマークダウンを入力・アップロードし、ブラウザ印刷API経由でPDFとして保存できるクライアントサイドツールを構築する。
+
+**Architecture:** `marked`（MD→HTML変換）+ CSS `@media print`（レイアウト制御）+ `window.print()`（出力）。PDF生成ライブラリ不要でレンダリング品質を最大化する。
+
+**Tech Stack:** React 18 + TypeScript, marked, DOMPurify, Tailwind CSS, shadcn/ui
+
+---
+
+## アプリ概要
+
+- **アプリ名:** `markdown-to-pdf`
+- **URL:** `tools.elchika.app/markdown-to-pdf/`
+- **分類:** テキスト系ツール
+- **完全クライアントサイド:** サーバー通信なし
+
+---
+
+## ファイル構成
+
+| ファイル | 操作 | 責務 |
+|---------|------|------|
+| `apps/markdown-to-pdf/src/App.tsx` | 新規作成 | UI全体（エディタ・プレビュー・設定・ファイル入力） |
+| `apps/markdown-to-pdf/src/utils/markdownConverter.ts` | 新規作成 | `marked` + `DOMPurify` によるMD→HTML変換（純粋関数） |
+| `apps/markdown-to-pdf/src/utils/printStyles.ts` | 新規作成 | 設定値（用紙サイズ・フォントサイズ）を受け取りCSS文字列を生成（純粋関数） |
+| `apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts` | 新規作成 | Markdown構文の変換テスト |
+| `apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts` | 新規作成 | CSS文字列生成テスト |
+| `apps/markdown-to-pdf/index.html` | 新規作成 | lang="ja", meta description, OGPタグ設定済み |
+| `apps/markdown-to-pdf/package.json` | 新規作成 | 依存関係（marked, dompurify） |
+| `apps/markdown-to-pdf/vite.config.ts` | 新規作成 | port: 3187 |
+| `packages/router/src/config/apps.ts` | 修正 | `markdown-to-pdf` ルーティング追加 |
+
+---
+
+## UI設計
+
+### レイアウト
+
+```
+┌─────────────────────────────────────────────────────┐
+│ header: ← Tools トップに戻る / h1 / 説明文           │
+├─────────────────────────────────────────────────────┤
+│ 設定バー: 用紙サイズ [A4▼]  フォントサイズ [中▼]     │
+├──────────────────────┬──────────────────────────────┤
+│ エディタ（左50%）     │  プレビュー（右50%）          │
+│  textarea            │  sanitized HTML レンダリング  │
+│  [📁 ファイルを開く] │  （リアルタイム更新）          │
+│  ドラッグ＆ドロップ  │                               │
+├──────────────────────┴──────────────────────────────┤
+│ [📥 PDF として保存]                                  │
+│ ※ 印刷ダイアログで「送信先: PDFに保存」を選択         │
+└─────────────────────────────────────────────────────┘
+```
+
+### 設定項目
+
+| 項目 | 選択肢 | デフォルト |
+|------|--------|-----------|
+| 用紙サイズ | A4 / Letter | A4 |
+| フォントサイズ | 小(12px) / 中(16px) / 大(20px) | 中(16px) |
+
+### ファイル入力
+
+- 「ファイルを開く」ボタン: `<input type="file" accept=".md,.markdown">` を非表示でトリガー
+- ドラッグ＆ドロップ: エディタ領域全体がドロップゾーン（`.md` / `.markdown` のみ受け付け）
+- FileReader API でテキスト読み込み → textarea に反映
+
+---
+
+## データフロー
+
+```
+[ユーザー入力 / ファイルアップロード]
+        ↓ markdownText (state)
+[markdownConverter.ts: marked(text) → HTML → DOMPurify.sanitize()]
+        ↓ sanitizedHtml (state)
+[プレビューパネル: サニタイズ済みHTMLをレンダリング]
+
+[「PDF として保存」クリック]
+        ↓ paperSize, fontSize (state)
+[printStyles.ts: generatePrintCSS({ paperSize, fontSize }) → CSS文字列]
+        ↓
+[DOM: <style id="md-print-styles"> を upsert]
+        ↓
+[window.print()]
+```
+
+---
+
+## `markdownConverter.ts` 設計
+
+```typescript
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+export function convertMarkdownToHtml(markdown: string): string {
+  const raw = marked(markdown) as string;
+  return DOMPurify.sanitize(raw);
+}
+```
+
+- `marked` のデフォルト設定を使用（GFM有効、表サポートあり）
+- `DOMPurify.sanitize()` でXSSを防ぐ（必須）
+- 戻り値はサニタイズ済みHTML文字列
+
+---
+
+## `printStyles.ts` 設計
+
+```typescript
+export type PaperSize = 'A4' | 'Letter';
+export type FontSize = 12 | 16 | 20;
+
+export function generatePrintCSS(options: { paperSize: PaperSize; fontSize: FontSize }): string {
+  return `@media print { ... }`;
+}
+```
+
+**`@media print` で適用するスタイル:**
+
+```css
+@media print {
+  /* エディタ・設定・ボタンを非表示にしてプレビューのみ印刷 */
+  body > #root > * { display: none !important; }
+  #pdf-preview { display: block !important; }
+
+  @page {
+    size: A4;          /* 設定値で切り替え */
+    margin: 2cm;
+  }
+
+  body {
+    font-size: 16px;   /* 設定値で切り替え */
+    font-family: 'Hiragino Sans', 'Yu Gothic', 'Meiryo', sans-serif;
+    color: #000;
+    background: #fff;
+  }
+
+  h1 { font-size: 2em; border-bottom: 2px solid #333; padding-bottom: 0.25em; margin-top: 1.5em; }
+  h2 { font-size: 1.5em; border-bottom: 1px solid #ccc; padding-bottom: 0.2em; margin-top: 1.2em; }
+  h3 { font-size: 1.25em; margin-top: 1em; }
+
+  pre { background: #f5f5f5; padding: 12px; border-radius: 4px; overflow: visible; white-space: pre-wrap; }
+  pre, code { font-family: 'Courier New', monospace; font-size: 0.875em; }
+  code:not(pre code) { background: #f0f0f0; padding: 2px 4px; border-radius: 3px; }
+
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+  th, td { border: 1px solid #ccc; padding: 8px 12px; }
+  th { background: #f5f5f5; font-weight: bold; }
+
+  hr { page-break-after: always; border: none; margin: 0; }
+
+  a { color: #000; text-decoration: underline; }
+  img { max-width: 100%; }
+
+  blockquote { border-left: 4px solid #ccc; margin-left: 0; padding-left: 1em; color: #555; }
+}
+```
+
+---
+
+## エクスポートフロー
+
+```typescript
+function handleExport() {
+  const css = generatePrintCSS({ paperSize, fontSize });
+  let styleEl = document.getElementById('md-print-styles') as HTMLStyleElement | null;
+  if (!styleEl) {
+    styleEl = document.createElement('style');
+    styleEl.id = 'md-print-styles';
+    document.head.appendChild(styleEl);
+  }
+  styleEl.textContent = css;
+  window.print();
+}
+```
+
+---
+
+## テスト設計
+
+### `markdownConverter.test.ts`
+
+| テストケース | 入力 | 期待出力 |
+|------------|------|---------|
+| 見出し変換 | `# Hello` | `<h1>Hello</h1>` を含む |
+| 箇条書き | `- item` | `<ul><li>item</li></ul>` を含む |
+| コードブロック | ` ```js\nconsole.log()\n``` ` | `<pre><code>` を含む |
+| 表 | GFM table syntax | `<table>` を含む |
+| XSS サニタイズ | `<script>alert(1)</script>` | `<script>` が除去される |
+| 空文字 | `""` | `""` を返す |
+
+### `printStyles.test.ts`
+
+| テストケース | 入力 | 期待出力 |
+|------------|------|---------|
+| A4 / 中 | `{ paperSize: 'A4', fontSize: 16 }` | `size: A4` と `font-size: 16px` を含む |
+| Letter / 小 | `{ paperSize: 'Letter', fontSize: 12 }` | `size: Letter` と `font-size: 12px` を含む |
+| 大フォント | `{ paperSize: 'A4', fontSize: 20 }` | `font-size: 20px` を含む |
+
+---
+
+## DS-001〜DS-010 チェックリスト
+
+- [x] DS-001: `min-h-screen bg-background` ラッパー
+- [x] DS-002: ヘッダーにバックリンク・h1・説明文
+- [x] DS-003: Button に `type="button"`
+- [x] DS-004: shadcn カラートークンのみ使用
+- [x] DS-005: `@/components/ui/` パスエイリアス
+- [x] DS-006: `<html lang="ja">`
+- [x] DS-007: meta description ツール固有
+- [x] DS-008: og:title / og:description
+- [x] DS-009: `max-w-7xl` コンテナ

--- a/.docs/plans/markdown-to-pdf-plan.md
+++ b/.docs/plans/markdown-to-pdf-plan.md
@@ -1,0 +1,871 @@
+# Markdown to PDF Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** マークダウンをブラウザ上でリアルタイムプレビューしながら `window.print()` 経由でPDFとして保存できるクライアントサイドSPAを構築する。
+
+**Architecture:** `marked.parse()` でMD→HTML変換、`DOMPurify.sanitize({ RETURN_DOM_FRAGMENT: true })` でXSSを防ぎつつDOMノードとして安全にレンダリング、`@media print` CSS + `window.print()` でPDF出力。innerHTML は使用しない。
+
+**Tech Stack:** React 19, TypeScript, marked, DOMPurify, Tailwind CSS 3.4, shadcn/ui, Vite+
+
+---
+
+## File Structure
+
+| ファイル | 操作 | 内容 |
+|---------|------|------|
+| `apps/markdown-to-pdf/package.json` | 新規作成 | 依存関係（marked, dompurify, @types/dompurify） |
+| `apps/markdown-to-pdf/index.html` | 新規作成 | lang="ja", meta description, OGP |
+| `apps/markdown-to-pdf/vite.config.ts` | 新規作成 | port: 5455, パスエイリアス |
+| `apps/markdown-to-pdf/tsconfig.json` | 新規作成 | tsconfig.base.json 継承 + パスエイリアス |
+| `apps/markdown-to-pdf/tailwind.config.js` | 新規作成 | shadcn/ui トークン設定 |
+| `apps/markdown-to-pdf/postcss.config.js` | 新規作成 | tailwindcss + autoprefixer |
+| `apps/markdown-to-pdf/wrangler.toml` | 新規作成 | レガシー設定 |
+| `apps/markdown-to-pdf/src/main.tsx` | 新規作成 | React エントリポイント |
+| `apps/markdown-to-pdf/src/index.css` | 新規作成 | Tailwind base + shadcn CSS 変数 |
+| `apps/markdown-to-pdf/src/components/ui/` | 新規作成 | shadcn/ui コンポーネント |
+| `apps/markdown-to-pdf/src/lib/utils.ts` | 新規作成 | `cn()` ユーティリティ |
+| `apps/markdown-to-pdf/src/hooks/useToast.ts` | 新規作成 | toast フック |
+| `apps/markdown-to-pdf/src/utils/markdownConverter.ts` | 新規作成 | marked + DOMPurify によるMD変換（文字列 / DOMFragment 両対応） |
+| `apps/markdown-to-pdf/src/utils/printStyles.ts` | 新規作成 | @media print CSS 文字列生成 |
+| `apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts` | 新規作成 | 変換ロジックテスト |
+| `apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts` | 新規作成 | CSS生成テスト |
+| `apps/markdown-to-pdf/src/App.tsx` | 新規作成 | メインUI |
+| `packages/router/src/config/apps.ts` | 修正 | `markdown-to-pdf` ルーティング追加 |
+
+---
+
+## Task 1: アプリスキャフォールド（設定ファイル群）
+
+**Files:**
+- Create: `apps/markdown-to-pdf/package.json`
+- Create: `apps/markdown-to-pdf/index.html`
+- Create: `apps/markdown-to-pdf/vite.config.ts`
+- Create: `apps/markdown-to-pdf/tsconfig.json`
+- Create: `apps/markdown-to-pdf/tailwind.config.js`
+- Create: `apps/markdown-to-pdf/postcss.config.js`
+- Create: `apps/markdown-to-pdf/wrangler.toml`
+
+- [ ] **Step 1: `package.json` を作成する**
+
+```json
+{
+  "name": "markdown-to-pdf",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview",
+    "type-check": "vp check",
+    "test": "vp test",
+    "test:watch": "vp test --watch",
+    "test:coverage": "vp test --coverage",
+    "lint": "vp check",
+    "lint:fix": "vp check --fix",
+    "format": "vp check --fix",
+    "format:check": "vp check",
+    "deploy": "vp build && wrangler pages deploy dist --project-name=tools-markdown-to-pdf"
+  },
+  "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toast": "^1.2.15",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "dompurify": "^3.2.6",
+    "lucide-react": "^0.546.0",
+    "marked": "^15.0.12",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.3.1"
+  },
+  "devDependencies": {
+    "@types/dompurify": "^3.0.5",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react-swc": "^4.3.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.0",
+    "tailwindcss-animate": "^1.0.7",
+    "vite": "^8.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: `index.html` を作成する**
+
+```html
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown to PDF - Elchika Tools</title>
+    <meta name="description" content="マークダウンをPDFとして保存できるブラウザツール。リアルタイムプレビュー付き。" />
+    <meta property="og:title" content="Markdown to PDF - Elchika Tools" />
+    <meta property="og:description" content="マークダウンをPDFとして保存できるブラウザツール。リアルタイムプレビュー付き。" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.elchika.app/markdown-to-pdf" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 3: `vite.config.ts` を作成する**
+
+```typescript
+import path from 'node:path';
+import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/',
+  server: {
+    port: 5455,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@components': path.resolve(__dirname, './src/components'),
+      '@utils': path.resolve(__dirname, './src/utils'),
+      '@types': path.resolve(__dirname, './src/types'),
+      '@config': path.resolve(__dirname, './src/config'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@services': path.resolve(__dirname, './src/services'),
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+});
+```
+
+- [ ] **Step 4: `tsconfig.json` を作成する**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "paths": {
+      "*": ["./*"],
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@types": ["./src/types"],
+      "@config/*": ["./src/config/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@services/*": ["./src/services/*"]
+    }
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 5: `tailwind.config.js` を作成する**
+
+`apps/url-encoder/tailwind.config.js` の内容をそのままコピーする:
+
+```bash
+cp apps/url-encoder/tailwind.config.js apps/markdown-to-pdf/tailwind.config.js
+```
+
+- [ ] **Step 6: `postcss.config.js` と `wrangler.toml` を作成する**
+
+`postcss.config.js`:
+```javascript
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
+`wrangler.toml`:
+```toml
+name = "tools-markdown-to-pdf"
+compatibility_date = "2024-10-19"
+```
+
+- [ ] **Step 7: `pnpm install` を実行する**
+
+```bash
+cd apps/markdown-to-pdf && pnpm install
+```
+
+Expected: `node_modules/marked`, `node_modules/dompurify`, `node_modules/@types/dompurify` が存在する。
+
+```bash
+ls node_modules | grep -E "^(marked|dompurify)$"
+```
+
+Expected: `dompurify` と `marked` が表示される。
+
+- [ ] **Step 8: コミットする**
+
+```bash
+cd ../..
+git add apps/markdown-to-pdf/package.json apps/markdown-to-pdf/index.html apps/markdown-to-pdf/vite.config.ts apps/markdown-to-pdf/tsconfig.json apps/markdown-to-pdf/tailwind.config.js apps/markdown-to-pdf/postcss.config.js apps/markdown-to-pdf/wrangler.toml
+git commit -m "chore: scaffold markdown-to-pdf app config files"
+```
+
+---
+
+## Task 2: shadcn/ui コンポーネント + エントリポイント
+
+**Files:**
+- Create: `apps/markdown-to-pdf/src/main.tsx`
+- Create: `apps/markdown-to-pdf/src/index.css`
+- Create: `apps/markdown-to-pdf/src/lib/utils.ts`
+- Create: `apps/markdown-to-pdf/src/hooks/useToast.ts`
+- Create: `apps/markdown-to-pdf/src/components/ui/{button,card,select,label,toast,toaster}.tsx`
+
+- [ ] **Step 1: ディレクトリを作成してファイルをコピーする**
+
+```bash
+mkdir -p apps/markdown-to-pdf/src/components/ui \
+         apps/markdown-to-pdf/src/hooks \
+         apps/markdown-to-pdf/src/lib
+
+cp apps/url-encoder/src/components/ui/button.tsx   apps/markdown-to-pdf/src/components/ui/
+cp apps/url-encoder/src/components/ui/card.tsx     apps/markdown-to-pdf/src/components/ui/
+cp apps/url-encoder/src/components/ui/select.tsx   apps/markdown-to-pdf/src/components/ui/
+cp apps/url-encoder/src/components/ui/label.tsx    apps/markdown-to-pdf/src/components/ui/
+cp apps/url-encoder/src/components/ui/toast.tsx    apps/markdown-to-pdf/src/components/ui/
+cp apps/url-encoder/src/components/ui/toaster.tsx  apps/markdown-to-pdf/src/components/ui/
+cp apps/url-encoder/src/hooks/useToast.ts          apps/markdown-to-pdf/src/hooks/
+cp apps/url-encoder/src/index.css                  apps/markdown-to-pdf/src/
+```
+
+- [ ] **Step 2: `src/lib/utils.ts` を作成する**
+
+```typescript
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+- [ ] **Step 3: `src/main.tsx` を作成する**
+
+```tsx
+import { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+```
+
+- [ ] **Step 4: コミットする**
+
+```bash
+git add apps/markdown-to-pdf/src/
+git commit -m "chore: add entry point and shadcn/ui components for markdown-to-pdf"
+```
+
+---
+
+## Task 3: `markdownConverter.ts` — TDD
+
+**Files:**
+- Create: `apps/markdown-to-pdf/src/utils/markdownConverter.ts`
+- Create: `apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts`
+
+- [ ] **Step 1: テストファイルを作成する**
+
+`apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { convertMarkdownToHtml } from '../markdownConverter';
+
+describe('convertMarkdownToHtml', () => {
+  it('空文字を渡すと空文字を返す', () => {
+    expect(convertMarkdownToHtml('')).toBe('');
+  });
+
+  it('h1 見出しを変換する', () => {
+    const result = convertMarkdownToHtml('# Hello');
+    expect(result).toContain('<h1>Hello</h1>');
+  });
+
+  it('h2 見出しを変換する', () => {
+    const result = convertMarkdownToHtml('## World');
+    expect(result).toContain('<h2>World</h2>');
+  });
+
+  it('箇条書きを変換する', () => {
+    const result = convertMarkdownToHtml('- item1\n- item2');
+    expect(result).toContain('<ul>');
+    expect(result).toContain('<li>item1</li>');
+  });
+
+  it('コードブロックを変換する', () => {
+    const result = convertMarkdownToHtml('```js\nconsole.log("hi")\n```');
+    expect(result).toContain('<pre>');
+    expect(result).toContain('<code>');
+  });
+
+  it('インラインコードを変換する', () => {
+    const result = convertMarkdownToHtml('use `npm install`');
+    expect(result).toContain('<code>npm install</code>');
+  });
+
+  it('GFM テーブルを変換する', () => {
+    const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = convertMarkdownToHtml(md);
+    expect(result).toContain('<table>');
+    expect(result).toContain('<th>');
+  });
+
+  it('script タグを除去してXSSを防ぐ', () => {
+    const result = convertMarkdownToHtml('<script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+  });
+
+  it('onerror 属性を除去する', () => {
+    const result = convertMarkdownToHtml('<img onerror="alert(1)" src="x">');
+    expect(result).not.toContain('onerror');
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```bash
+cd apps/markdown-to-pdf && vp test src/utils/__tests__/markdownConverter.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../markdownConverter'`
+
+- [ ] **Step 3: `markdownConverter.ts` を実装する**
+
+`apps/markdown-to-pdf/src/utils/markdownConverter.ts`:
+
+```typescript
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+marked.use({ gfm: true });
+
+export function convertMarkdownToHtml(markdown: string): string {
+  if (!markdown) return '';
+  const raw = marked.parse(markdown) as string;
+  return DOMPurify.sanitize(raw);
+}
+
+export function convertMarkdownToFragment(markdown: string): DocumentFragment {
+  const raw = markdown ? (marked.parse(markdown) as string) : '';
+  return DOMPurify.sanitize(raw, { RETURN_DOM_FRAGMENT: true }) as DocumentFragment;
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+```bash
+cd apps/markdown-to-pdf && vp test src/utils/__tests__/markdownConverter.test.ts
+```
+
+Expected: PASS (9/9)
+
+- [ ] **Step 5: コミットする**
+
+```bash
+cd ../..
+git add apps/markdown-to-pdf/src/utils/markdownConverter.ts apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts
+git commit -m "feat(markdown-to-pdf): add markdownConverter with XSS sanitization"
+```
+
+---
+
+## Task 4: `printStyles.ts` — TDD
+
+**Files:**
+- Create: `apps/markdown-to-pdf/src/utils/printStyles.ts`
+- Create: `apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts`
+
+- [ ] **Step 1: テストファイルを作成する**
+
+`apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { generatePrintCSS } from '../printStyles';
+
+describe('generatePrintCSS', () => {
+  it('A4 サイズを含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('size: A4');
+  });
+
+  it('Letter サイズを含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'Letter', fontSize: 16 });
+    expect(css).toContain('size: Letter');
+  });
+
+  it('フォントサイズ 12px を含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 12 });
+    expect(css).toContain('font-size: 12px');
+  });
+
+  it('フォントサイズ 16px を含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('font-size: 16px');
+  });
+
+  it('フォントサイズ 20px を含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 20 });
+    expect(css).toContain('font-size: 20px');
+  });
+
+  it('@media print ブロックを含む', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('@media print');
+  });
+
+  it('#pdf-preview を表示する指定を含む', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('#pdf-preview');
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認する**
+
+```bash
+cd apps/markdown-to-pdf && vp test src/utils/__tests__/printStyles.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../printStyles'`
+
+- [ ] **Step 3: `printStyles.ts` を実装する**
+
+`apps/markdown-to-pdf/src/utils/printStyles.ts`:
+
+```typescript
+export type PaperSize = 'A4' | 'Letter';
+export type FontSize = 12 | 16 | 20;
+
+export interface PrintOptions {
+  paperSize: PaperSize;
+  fontSize: FontSize;
+}
+
+export function generatePrintCSS({ paperSize, fontSize }: PrintOptions): string {
+  return `@media print {
+  body > #root > * { display: none !important; }
+  #pdf-preview { display: block !important; }
+
+  @page {
+    size: ${paperSize};
+    margin: 2cm;
+  }
+
+  body {
+    font-size: ${fontSize}px;
+    font-family: 'Hiragino Sans', 'Yu Gothic', 'Meiryo', sans-serif;
+    color: #000;
+    background: #fff;
+  }
+
+  h1 { font-size: 2em; border-bottom: 2px solid #333; padding-bottom: 0.25em; margin-top: 1.5em; }
+  h2 { font-size: 1.5em; border-bottom: 1px solid #ccc; padding-bottom: 0.2em; margin-top: 1.2em; }
+  h3 { font-size: 1.25em; margin-top: 1em; }
+  h4, h5, h6 { margin-top: 0.8em; }
+
+  p { margin: 0.75em 0; line-height: 1.7; }
+
+  pre {
+    background: #f5f5f5;
+    padding: 12px;
+    border-radius: 4px;
+    overflow: visible;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  pre, code { font-family: 'Courier New', monospace; font-size: 0.875em; }
+  code:not(pre code) { background: #f0f0f0; padding: 2px 4px; border-radius: 3px; }
+
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+  th, td { border: 1px solid #ccc; padding: 8px 12px; }
+  th { background: #f5f5f5; font-weight: bold; }
+
+  hr { page-break-after: always; border: none; margin: 0; }
+
+  a { color: #000; text-decoration: underline; }
+  img { max-width: 100%; height: auto; }
+
+  blockquote {
+    border-left: 4px solid #ccc;
+    margin: 1em 0;
+    padding: 0.5em 1em;
+    color: #555;
+    background: #fafafa;
+  }
+
+  ul, ol { padding-left: 2em; margin: 0.5em 0; }
+  li { margin: 0.25em 0; }
+}`;
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認する**
+
+```bash
+cd apps/markdown-to-pdf && vp test src/utils/__tests__/printStyles.test.ts
+```
+
+Expected: PASS (7/7)
+
+- [ ] **Step 5: コミットする**
+
+```bash
+cd ../..
+git add apps/markdown-to-pdf/src/utils/printStyles.ts apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts
+git commit -m "feat(markdown-to-pdf): add printStyles CSS generator"
+```
+
+---
+
+## Task 5: `App.tsx` — メインUI
+
+**Files:**
+- Create: `apps/markdown-to-pdf/src/App.tsx`
+
+- [ ] **Step 1: `App.tsx` を作成する**
+
+`apps/markdown-to-pdf/src/App.tsx`:
+
+```tsx
+import { FileText, Upload } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Toaster } from '@/components/ui/toaster';
+import { useToast } from '@/hooks/useToast';
+import { convertMarkdownToFragment } from '@/utils/markdownConverter';
+import { type FontSize, type PaperSize, generatePrintCSS } from '@/utils/printStyles';
+
+const SAMPLE_MARKDOWN = `# マークダウンのサンプル
+
+これは **太字** と *斜体* のテキストです。
+
+## 機能一覧
+
+- リアルタイムプレビュー
+- ファイルアップロード対応（.md）
+- 用紙サイズ・フォントサイズ設定
+
+## コード例
+
+\`\`\`javascript
+console.log('Hello, World!');
+\`\`\`
+
+インラインコードは \`const x = 1\` のように書けます。
+
+## テーブル
+
+| 項目 | 説明 |
+|------|------|
+| A4   | 210 × 297mm |
+| Letter | 215.9 × 279.4mm |
+
+> 印刷ダイアログで「送信先: PDFに保存」を選択してください。
+
+---
+
+2ページ目はここから始まります。
+`;
+
+export default function App() {
+  const [markdown, setMarkdown] = useState(SAMPLE_MARKDOWN);
+  const [paperSize, setPaperSize] = useState<PaperSize>('A4');
+  const [fontSize, setFontSize] = useState<FontSize>(16);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const el = previewRef.current;
+    if (!el) return;
+    const fragment = convertMarkdownToFragment(markdown);
+    el.replaceChildren(fragment);
+  }, [markdown]);
+
+  const handleFileRead = useCallback(
+    (file: File) => {
+      if (!file.name.endsWith('.md') && !file.name.endsWith('.markdown')) {
+        toast({ title: '.md または .markdown ファイルのみ対応しています', variant: 'destructive' });
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => setMarkdown((e.target?.result as string) ?? '');
+      reader.readAsText(file);
+    },
+    [toast]
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFileRead(file);
+      e.target.value = '';
+    },
+    [handleFileRead]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) handleFileRead(file);
+    },
+    [handleFileRead]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const handleExport = useCallback(() => {
+    const css = generatePrintCSS({ paperSize, fontSize });
+    let styleEl = document.getElementById('md-print-styles') as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = 'md-print-styles';
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = css;
+    window.print();
+  }, [paperSize, fontSize]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b bg-card shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="mb-2">
+            <a href="/" className="text-sm text-primary hover:underline">
+              ← Tools トップに戻る
+            </a>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">📄 Markdown to PDF</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            マークダウンを入力またはファイルをアップロードして、PDFとして保存できます。
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-4 flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-foreground" htmlFor="paper-size">
+              用紙サイズ
+            </label>
+            <Select value={paperSize} onValueChange={(v) => setPaperSize(v as PaperSize)}>
+              <SelectTrigger id="paper-size" className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="A4">A4</SelectItem>
+                <SelectItem value="Letter">Letter</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-foreground" htmlFor="font-size">
+              フォントサイズ
+            </label>
+            <Select
+              value={String(fontSize)}
+              onValueChange={(v) => setFontSize(Number(v) as FontSize)}
+            >
+              <SelectTrigger id="font-size" className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="12">小 (12px)</SelectItem>
+                <SelectItem value="16">中 (16px)</SelectItem>
+                <SelectItem value="20">大 (20px)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card
+            className={isDragOver ? 'border-primary ring-2 ring-primary' : ''}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+          >
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-base">マークダウン</CardTitle>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="mr-1 h-3 w-3" />
+                ファイルを開く
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".md,.markdown"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+            </CardHeader>
+            <CardContent>
+              <textarea
+                aria-label="マークダウン入力"
+                className="flex min-h-[520px] w-full resize-none rounded-md border border-input bg-background px-3 py-2 font-mono text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                value={markdown}
+                onChange={(e) => setMarkdown(e.target.value)}
+                placeholder=".md ファイルをドロップするか、マークダウンを入力してください..."
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">プレビュー</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div
+                ref={previewRef}
+                id="pdf-preview"
+                className="prose prose-sm min-h-[520px] max-w-none rounded-md border border-input bg-background px-4 py-3"
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="mt-6 flex flex-col items-center gap-2">
+          <Button type="button" size="lg" onClick={handleExport}>
+            <FileText className="mr-2 h-4 w-4" />
+            PDF として保存
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            印刷ダイアログで「送信先: PDF に保存」を選択してください
+          </p>
+        </div>
+      </main>
+
+      <Toaster />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: 開発サーバーで動作確認する**
+
+```bash
+cd apps/markdown-to-pdf && vp dev
+```
+
+ブラウザで `http://localhost:5455` を開き、以下を確認する:
+1. サンプルマークダウンがプレビューパネルに正しくレンダリングされる
+2. テキストエリアを編集するとプレビューがリアルタイムに更新される
+3. 「ファイルを開く」で `.md` ファイルを選択するとエディタに反映される
+4. `.md` ファイルをエディタ領域にドラッグ＆ドロップできる
+5. 「PDF として保存」ボタンで印刷ダイアログが開く
+6. 印刷プレビューにはマークダウンのレンダリング結果のみ表示される（エディタ・ボタンは非表示）
+7. 用紙サイズ・フォントサイズを変えて再エクスポートすると設定が反映される
+
+- [ ] **Step 3: コミットする**
+
+```bash
+cd ../..
+git add apps/markdown-to-pdf/src/App.tsx
+git commit -m "feat(markdown-to-pdf): implement main UI with editor, preview, and PDF export"
+```
+
+---
+
+## Task 6: ルーター登録
+
+**Files:**
+- Modify: `packages/router/src/config/apps.ts`
+
+- [ ] **Step 1: `apps.ts` に `markdown-to-pdf` を追加する**
+
+`packages/router/src/config/apps.ts` の `text-markdown-preview` の直後に以下を追加する:
+
+```typescript
+{ path: '/markdown-to-pdf', url: 'https://tools-markdown-to-pdf.elchika.app', icon: '📄', displayName: 'Markdown to PDF', description: 'MarkdownをPDFとして保存', category: 'Text' },
+```
+
+- [ ] **Step 2: 追加を確認する**
+
+```bash
+grep "markdown-to-pdf" packages/router/src/config/apps.ts
+```
+
+Expected: 上記行が1行表示される。
+
+- [ ] **Step 3: コミットする**
+
+```bash
+git add packages/router/src/config/apps.ts
+git commit -m "feat(router): register markdown-to-pdf app"
+```
+
+---
+
+## 完了確認
+
+全タスク完了後に以下を確認する:
+
+```bash
+# ユニットテスト全通過
+cd apps/markdown-to-pdf && vp test
+
+# DS-001〜DS-010 監査
+cd ../.. && node scripts/design-audit.js --app=markdown-to-pdf
+```
+
+Expected:
+- テスト: 16件以上 PASS
+- 監査: `✅ 準拠: 1 / 1` (MUST 違反 0件)

--- a/apps/markdown-to-pdf/index.html
+++ b/apps/markdown-to-pdf/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Markdown to PDF - Elchika Tools</title>
+    <meta name="description" content="マークダウンをPDFとして保存できるブラウザツール。リアルタイムプレビュー付き。" />
+    <meta property="og:title" content="Markdown to PDF - Elchika Tools" />
+    <meta property="og:description" content="マークダウンをPDFとして保存できるブラウザツール。リアルタイムプレビュー付き。" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://tools.elchika.app/markdown-to-pdf" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/markdown-to-pdf/package.json
+++ b/apps/markdown-to-pdf/package.json
@@ -32,7 +32,6 @@
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
-    "@types/dompurify": "^3.0.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react-swc": "^4.3.0",
@@ -40,6 +39,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.9.3",
     "vite": "^8.0.0"
   }
 }

--- a/apps/markdown-to-pdf/package.json
+++ b/apps/markdown-to-pdf/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.0.0",
+    "happy-dom": "^20.0.10",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react-swc": "^4.3.0",
     "autoprefixer": "^10.4.21",

--- a/apps/markdown-to-pdf/package.json
+++ b/apps/markdown-to-pdf/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "markdown-to-pdf",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview",
+    "type-check": "vp check",
+    "test": "vp test",
+    "test:watch": "vp test --watch",
+    "test:coverage": "vp test --coverage",
+    "lint": "vp check",
+    "lint:fix": "vp check --fix",
+    "format": "vp check --fix",
+    "format:check": "vp check",
+    "deploy": "vp build && wrangler pages deploy dist --project-name=tools-markdown-to-pdf"
+  },
+  "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-toast": "^1.2.15",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "dompurify": "^3.2.6",
+    "lucide-react": "^0.546.0",
+    "marked": "^15.0.12",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.3.1"
+  },
+  "devDependencies": {
+    "@types/dompurify": "^3.0.5",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react-swc": "^4.3.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.0",
+    "tailwindcss-animate": "^1.0.7",
+    "vite": "^8.0.0"
+  }
+}

--- a/apps/markdown-to-pdf/postcss.config.js
+++ b/apps/markdown-to-pdf/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/markdown-to-pdf/src/App.tsx
+++ b/apps/markdown-to-pdf/src/App.tsx
@@ -100,7 +100,7 @@ export default function App() {
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
     setIsDragOver(false);
   }, []);
 

--- a/apps/markdown-to-pdf/src/App.tsx
+++ b/apps/markdown-to-pdf/src/App.tsx
@@ -1,0 +1,236 @@
+import { FileText, Upload } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Toaster } from '@/components/ui/toaster';
+import { useToast } from '@/hooks/useToast';
+import { convertMarkdownToFragment } from '@/utils/markdownConverter';
+import { type FontSize, type PaperSize, generatePrintCSS } from '@/utils/printStyles';
+
+const SAMPLE_MARKDOWN = `# マークダウンのサンプル
+
+これは **太字** と *斜体* のテキストです。
+
+## 機能一覧
+
+- リアルタイムプレビュー
+- ファイルアップロード対応（.md）
+- 用紙サイズ・フォントサイズ設定
+
+## コード例
+
+\`\`\`javascript
+console.log('Hello, World!');
+\`\`\`
+
+インラインコードは \`const x = 1\` のように書けます。
+
+## テーブル
+
+| 項目 | 説明 |
+|------|------|
+| A4   | 210 × 297mm |
+| Letter | 215.9 × 279.4mm |
+
+> 印刷ダイアログで「送信先: PDFに保存」を選択してください。
+
+---
+
+2ページ目はここから始まります。
+`;
+
+export default function App() {
+  const [markdown, setMarkdown] = useState(SAMPLE_MARKDOWN);
+  const [paperSize, setPaperSize] = useState<PaperSize>('A4');
+  const [fontSize, setFontSize] = useState<FontSize>(16);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const el = previewRef.current;
+    if (!el) return;
+    const fragment = convertMarkdownToFragment(markdown);
+    el.replaceChildren(fragment);
+  }, [markdown]);
+
+  const handleFileRead = useCallback(
+    (file: File) => {
+      if (!file.name.endsWith('.md') && !file.name.endsWith('.markdown')) {
+        toast({ title: '.md または .markdown ファイルのみ対応しています', variant: 'destructive' });
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => setMarkdown((e.target?.result as string) ?? '');
+      reader.readAsText(file);
+    },
+    [toast]
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFileRead(file);
+      e.target.value = '';
+    },
+    [handleFileRead]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (file) handleFileRead(file);
+    },
+    [handleFileRead]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const handleExport = useCallback(() => {
+    const css = generatePrintCSS({ paperSize, fontSize });
+    let styleEl = document.getElementById('md-print-styles') as HTMLStyleElement | null;
+    if (!styleEl) {
+      styleEl = document.createElement('style');
+      styleEl.id = 'md-print-styles';
+      document.head.appendChild(styleEl);
+    }
+    styleEl.textContent = css;
+    window.print();
+  }, [paperSize, fontSize]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b bg-card shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="mb-2">
+            <a href="/" className="text-sm text-primary hover:underline">
+              ← Tools トップに戻る
+            </a>
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">📄 Markdown to PDF</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            マークダウンを入力またはファイルをアップロードして、PDFとして保存できます。
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-4 flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-foreground" htmlFor="paper-size">
+              用紙サイズ
+            </label>
+            <Select value={paperSize} onValueChange={(v) => setPaperSize(v as PaperSize)}>
+              <SelectTrigger id="paper-size" className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="A4">A4</SelectItem>
+                <SelectItem value="Letter">Letter</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm font-medium text-foreground" htmlFor="font-size">
+              フォントサイズ
+            </label>
+            <Select
+              value={String(fontSize)}
+              onValueChange={(v) => setFontSize(Number(v) as FontSize)}
+            >
+              <SelectTrigger id="font-size" className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="12">小 (12px)</SelectItem>
+                <SelectItem value="16">中 (16px)</SelectItem>
+                <SelectItem value="20">大 (20px)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <Card
+            className={isDragOver ? 'border-primary ring-2 ring-primary' : ''}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+          >
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-base">マークダウン</CardTitle>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="mr-1 h-3 w-3" />
+                ファイルを開く
+              </Button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".md,.markdown"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+            </CardHeader>
+            <CardContent>
+              <textarea
+                aria-label="マークダウン入力"
+                className="flex min-h-[520px] w-full resize-none rounded-md border border-input bg-background px-3 py-2 font-mono text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                value={markdown}
+                onChange={(e) => setMarkdown(e.target.value)}
+                placeholder=".md ファイルをドロップするか、マークダウンを入力してください..."
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">プレビュー</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div
+                ref={previewRef}
+                id="pdf-preview"
+                className="min-h-[520px] rounded-md border border-input bg-background px-4 py-3 text-sm leading-relaxed"
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="mt-6 flex flex-col items-center gap-2">
+          <Button type="button" size="lg" onClick={handleExport}>
+            <FileText className="mr-2 h-4 w-4" />
+            PDF として保存
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            印刷ダイアログで「送信先: PDF に保存」を選択してください
+          </p>
+        </div>
+      </main>
+
+      <Toaster />
+    </div>
+  );
+}

--- a/apps/markdown-to-pdf/src/components/ui/button.tsx
+++ b/apps/markdown-to-pdf/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/apps/markdown-to-pdf/src/components/ui/card.tsx
+++ b/apps/markdown-to-pdf/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/apps/markdown-to-pdf/src/components/ui/label.tsx
+++ b/apps/markdown-to-pdf/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/apps/markdown-to-pdf/src/components/ui/select.tsx
+++ b/apps/markdown-to-pdf/src/components/ui/select.tsx
@@ -1,0 +1,151 @@
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '../../lib/utils';
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn('flex cursor-default items-center justify-center py-1', className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/apps/markdown-to-pdf/src/components/ui/toast.tsx
+++ b/apps/markdown-to-pdf/src/components/ui/toast.tsx
@@ -1,0 +1,122 @@
+import * as ToastPrimitives from '@radix-ui/react-toast';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      className
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  {
+    variants: {
+      variant: {
+        default: 'border bg-background text-foreground',
+        destructive:
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
+        success: 'border-green-500 bg-green-50 text-green-900',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      className
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title ref={ref} className={cn('text-sm font-semibold', className)} {...props} />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn('text-sm opacity-90', className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+};

--- a/apps/markdown-to-pdf/src/components/ui/toaster.tsx
+++ b/apps/markdown-to-pdf/src/components/ui/toaster.tsx
@@ -1,0 +1,29 @@
+import { useToast } from '@hooks/useToast';
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from './toast';
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(({ id, title, description, action, ...props }) => (
+        <Toast key={id} {...props}>
+          <div className="grid gap-1">
+            {title && <ToastTitle>{title}</ToastTitle>}
+            {description && <ToastDescription>{description}</ToastDescription>}
+          </div>
+          {action}
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/apps/markdown-to-pdf/src/hooks/useToast.ts
+++ b/apps/markdown-to-pdf/src/hooks/useToast.ts
@@ -1,0 +1,183 @@
+import type { ToastActionElement, ToastProps } from '@components/ui/toast';
+import * as React from 'react';
+
+const TOAST_LIMIT = 3;
+const TOAST_REMOVE_DELAY = 5000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+const _actionTypes = {
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+} as const;
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+
+type ActionType = typeof _actionTypes;
+
+type Action =
+  | {
+      type: ActionType['ADD_TOAST'];
+      toast: ToasterToast;
+    }
+  | {
+      type: ActionType['UPDATE_TOAST'];
+      toast: Partial<ToasterToast>;
+    }
+  | {
+      type: ActionType['DISMISS_TOAST'];
+      toastId?: ToasterToast['id'] | undefined;
+    }
+  | {
+      type: ActionType['REMOVE_TOAST'];
+      toastId?: ToasterToast['id'] | undefined;
+    };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: 'REMOVE_TOAST',
+      toastId: toastId,
+    });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'ADD_TOAST':
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map((t) => (t.id === action.toast.id ? { ...t, ...action.toast } : t)),
+      };
+
+    case 'DISMISS_TOAST': {
+      const { toastId } = action;
+
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      };
+    }
+    case 'REMOVE_TOAST':
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, 'id'>;
+
+function toast({ ...props }: Toast) {
+  const id = genId();
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: 'UPDATE_TOAST',
+      toast: { ...props, id },
+    });
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id });
+
+  dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss();
+      },
+    },
+  });
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, []);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
+  };
+}
+
+export { useToast, toast };

--- a/apps/markdown-to-pdf/src/index.css
+++ b/apps/markdown-to-pdf/src/index.css
@@ -1,0 +1,69 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 212.7 26.8% 83.9%;
+    --chart-1: 220 70% 50%;
+    --chart-2: 160 60% 45%;
+    --chart-3: 30 80% 55%;
+    --chart-4: 280 65% 60%;
+    --chart-5: 340 75% 55%;
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/markdown-to-pdf/src/lib/utils.ts
+++ b/apps/markdown-to-pdf/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/markdown-to-pdf/src/main.tsx
+++ b/apps/markdown-to-pdf/src/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts
+++ b/apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertMarkdownToHtml } from '../markdownConverter';
+import { convertMarkdownToFragment, convertMarkdownToHtml } from '../markdownConverter';
 
 describe('convertMarkdownToHtml', () => {
   it('空文字を渡すと空文字を返す', () => {
@@ -48,5 +48,24 @@ describe('convertMarkdownToHtml', () => {
   it('onerror 属性を除去する', () => {
     const result = convertMarkdownToHtml('<img onerror="alert(1)" src="x">');
     expect(result).not.toContain('onerror');
+  });
+});
+
+describe('convertMarkdownToFragment', () => {
+  it('DocumentFragment を返す', () => {
+    const fragment = convertMarkdownToFragment('# Hello');
+    expect(fragment).toBeInstanceOf(DocumentFragment);
+  });
+
+  it('h1 要素を含む Fragment を返す', () => {
+    const fragment = convertMarkdownToFragment('# Hello');
+    const div = document.createElement('div');
+    div.appendChild(fragment.cloneNode(true));
+    expect(div.querySelector('h1')).not.toBeNull();
+  });
+
+  it('空文字の場合も DocumentFragment を返す', () => {
+    const fragment = convertMarkdownToFragment('');
+    expect(fragment).toBeInstanceOf(DocumentFragment);
   });
 });

--- a/apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts
+++ b/apps/markdown-to-pdf/src/utils/__tests__/markdownConverter.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { convertMarkdownToHtml } from '../markdownConverter';
+
+describe('convertMarkdownToHtml', () => {
+  it('空文字を渡すと空文字を返す', () => {
+    expect(convertMarkdownToHtml('')).toBe('');
+  });
+
+  it('h1 見出しを変換する', () => {
+    const result = convertMarkdownToHtml('# Hello');
+    expect(result).toContain('<h1>Hello</h1>');
+  });
+
+  it('h2 見出しを変換する', () => {
+    const result = convertMarkdownToHtml('## World');
+    expect(result).toContain('<h2>World</h2>');
+  });
+
+  it('箇条書きを変換する', () => {
+    const result = convertMarkdownToHtml('- item1\n- item2');
+    expect(result).toContain('<ul>');
+    expect(result).toContain('<li>item1</li>');
+  });
+
+  it('コードブロックを変換する', () => {
+    const result = convertMarkdownToHtml('```js\nconsole.log("hi")\n```');
+    expect(result).toContain('<pre>');
+    expect(result).toContain('<code');
+  });
+
+  it('インラインコードを変換する', () => {
+    const result = convertMarkdownToHtml('use `npm install`');
+    expect(result).toContain('<code>npm install</code>');
+  });
+
+  it('GFM テーブルを変換する', () => {
+    const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+    const result = convertMarkdownToHtml(md);
+    expect(result).toContain('<table>');
+    expect(result).toContain('<th>');
+  });
+
+  it('script タグを除去してXSSを防ぐ', () => {
+    const result = convertMarkdownToHtml('<script>alert(1)</script>');
+    expect(result).not.toContain('<script>');
+  });
+
+  it('onerror 属性を除去する', () => {
+    const result = convertMarkdownToHtml('<img onerror="alert(1)" src="x">');
+    expect(result).not.toContain('onerror');
+  });
+});

--- a/apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts
+++ b/apps/markdown-to-pdf/src/utils/__tests__/printStyles.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { generatePrintCSS } from '../printStyles';
+
+describe('generatePrintCSS', () => {
+  it('A4 サイズを含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('size: A4');
+  });
+
+  it('Letter サイズを含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'Letter', fontSize: 16 });
+    expect(css).toContain('size: Letter');
+  });
+
+  it('フォントサイズ 12px を含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 12 });
+    expect(css).toContain('font-size: 12px');
+  });
+
+  it('フォントサイズ 16px を含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('font-size: 16px');
+  });
+
+  it('フォントサイズ 20px を含む CSS を生成する', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 20 });
+    expect(css).toContain('font-size: 20px');
+  });
+
+  it('@media print ブロックを含む', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('@media print');
+  });
+
+  it('#pdf-preview を表示する指定を含む', () => {
+    const css = generatePrintCSS({ paperSize: 'A4', fontSize: 16 });
+    expect(css).toContain('#pdf-preview');
+  });
+});

--- a/apps/markdown-to-pdf/src/utils/markdownConverter.ts
+++ b/apps/markdown-to-pdf/src/utils/markdownConverter.ts
@@ -9,11 +9,11 @@ function getPurify() {
 
 export function convertMarkdownToHtml(markdown: string): string {
   if (!markdown) return '';
-  const raw = marked.parse(markdown) as string;
+  const raw = marked.parse(markdown, { async: false });
   return getPurify().sanitize(raw);
 }
 
 export function convertMarkdownToFragment(markdown: string): DocumentFragment {
-  const raw = markdown ? (marked.parse(markdown) as string) : '';
+  const raw = markdown ? marked.parse(markdown, { async: false }) : '';
   return getPurify().sanitize(raw, { RETURN_DOM_FRAGMENT: true }) as DocumentFragment;
 }

--- a/apps/markdown-to-pdf/src/utils/markdownConverter.ts
+++ b/apps/markdown-to-pdf/src/utils/markdownConverter.ts
@@ -1,0 +1,19 @@
+import createDOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+marked.use({ gfm: true });
+
+function getPurify() {
+  return createDOMPurify(window);
+}
+
+export function convertMarkdownToHtml(markdown: string): string {
+  if (!markdown) return '';
+  const raw = marked.parse(markdown) as string;
+  return getPurify().sanitize(raw);
+}
+
+export function convertMarkdownToFragment(markdown: string): DocumentFragment {
+  const raw = markdown ? (marked.parse(markdown) as string) : '';
+  return getPurify().sanitize(raw, { RETURN_DOM_FRAGMENT: true }) as DocumentFragment;
+}

--- a/apps/markdown-to-pdf/src/utils/printStyles.ts
+++ b/apps/markdown-to-pdf/src/utils/printStyles.ts
@@ -1,0 +1,64 @@
+export type PaperSize = 'A4' | 'Letter';
+export type FontSize = 12 | 16 | 20;
+
+export interface PrintOptions {
+  paperSize: PaperSize;
+  fontSize: FontSize;
+}
+
+export function generatePrintCSS({ paperSize, fontSize }: PrintOptions): string {
+  return `@media print {
+  body > #root > * { display: none !important; }
+  #pdf-preview { display: block !important; }
+
+  @page {
+    size: ${paperSize};
+    margin: 2cm;
+  }
+
+  body {
+    font-size: ${fontSize}px;
+    font-family: 'Hiragino Sans', 'Yu Gothic', 'Meiryo', sans-serif;
+    color: #000;
+    background: #fff;
+  }
+
+  h1 { font-size: 2em; border-bottom: 2px solid #333; padding-bottom: 0.25em; margin-top: 1.5em; }
+  h2 { font-size: 1.5em; border-bottom: 1px solid #ccc; padding-bottom: 0.2em; margin-top: 1.2em; }
+  h3 { font-size: 1.25em; margin-top: 1em; }
+  h4, h5, h6 { margin-top: 0.8em; }
+
+  p { margin: 0.75em 0; line-height: 1.7; }
+
+  pre {
+    background: #f5f5f5;
+    padding: 12px;
+    border-radius: 4px;
+    overflow: visible;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  pre, code { font-family: 'Courier New', monospace; font-size: 0.875em; }
+  code:not(pre code) { background: #f0f0f0; padding: 2px 4px; border-radius: 3px; }
+
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+  th, td { border: 1px solid #ccc; padding: 8px 12px; }
+  th { background: #f5f5f5; font-weight: bold; }
+
+  hr { page-break-after: always; border: none; margin: 0; }
+
+  a { color: #000; text-decoration: underline; }
+  img { max-width: 100%; height: auto; }
+
+  blockquote {
+    border-left: 4px solid #ccc;
+    margin: 1em 0;
+    padding: 0.5em 1em;
+    color: #555;
+    background: #fafafa;
+  }
+
+  ul, ol { padding-left: 2em; margin: 0.5em 0; }
+  li { margin: 0.25em 0; }
+}`;
+}

--- a/apps/markdown-to-pdf/tailwind.config.js
+++ b/apps/markdown-to-pdf/tailwind.config.js
@@ -1,0 +1,57 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        chart: {
+          1: 'hsl(var(--chart-1))',
+          2: 'hsl(var(--chart-2))',
+          3: 'hsl(var(--chart-3))',
+          4: 'hsl(var(--chart-4))',
+          5: 'hsl(var(--chart-5))',
+        },
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};

--- a/apps/markdown-to-pdf/tsconfig.json
+++ b/apps/markdown-to-pdf/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "paths": {
+      "*": ["./*"],
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@types": ["./src/types"],
+      "@config/*": ["./src/config/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@services/*": ["./src/services/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/markdown-to-pdf/vite.config.ts
+++ b/apps/markdown-to-pdf/vite.config.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/',
+  server: {
+    port: 5455,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@components': path.resolve(__dirname, './src/components'),
+      '@utils': path.resolve(__dirname, './src/utils'),
+      '@types': path.resolve(__dirname, './src/types'),
+      '@config': path.resolve(__dirname, './src/config'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@services': path.resolve(__dirname, './src/services'),
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    sourcemap: false,
+  },
+});

--- a/apps/markdown-to-pdf/vite.config.ts
+++ b/apps/markdown-to-pdf/vite.config.ts
@@ -24,4 +24,7 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: false,
   },
+  test: {
+    environment: 'happy-dom',
+  },
 });

--- a/apps/markdown-to-pdf/wrangler.toml
+++ b/apps/markdown-to-pdf/wrangler.toml
@@ -1,0 +1,2 @@
+name = "tools-markdown-to-pdf"
+compatibility_date = "2024-10-19"

--- a/packages/router/src/config/apps.ts
+++ b/packages/router/src/config/apps.ts
@@ -37,6 +37,7 @@ export const APPS_CONFIG: readonly AppConfig[] = [
   { path: '/text-kana-converter', url: 'https://tools-text-kana-converter.elchika.app', icon: 'あ', displayName: 'Kana Converter', description: 'ひらがな・カタカナ変換', category: 'Text' },
   { path: '/text-bionic-reading', url: 'https://tools-text-bionic-reading.elchika.app', icon: '👁', displayName: 'Bionic Reading', description: 'Bionic Reading変換', category: 'Text' },
   { path: '/text-markdown-html', url: 'https://tools-text-markdown-html.elchika.app', icon: '📑', displayName: 'Markdown to HTML', description: 'Markdown→HTML変換', category: 'Text' },
+  { path: '/markdown-to-pdf', url: 'https://tools-markdown-to-pdf.elchika.app', icon: '📄', displayName: 'Markdown to PDF', description: 'MarkdownをPDFとして保存', category: 'Text' },
   { path: '/text-markdown-preview', url: 'https://tools-text-markdown-preview.elchika.app', icon: '👀', displayName: 'Markdown Preview', description: 'Markdownプレビュー', category: 'Text' },
 
   // ── Encode ──

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11776,6 +11776,76 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7)
 
+  apps/markdown-to-pdf:
+    dependencies:
+      '@radix-ui/react-label':
+        specifier: ^2.1.7
+        version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.15
+        version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.4.7
+      lucide-react:
+        specifier: ^0.546.0
+        version: 0.546.0(react@19.2.4)
+      marked:
+        specifier: ^15.0.12
+        version: 15.0.12
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.5.0
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react-swc':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7))
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.27(postcss@8.5.8)
+      happy-dom:
+        specifier: ^20.0.10
+        version: 20.8.4
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.8
+      tailwindcss:
+        specifier: ^3.4.0
+        version: 3.4.19
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.19)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@1.21.7)
+
   apps/markdown-to-slides:
     dependencies:
       '@radix-ui/react-label':
@@ -21757,6 +21827,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -22205,6 +22278,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dompurify@3.4.7:
+    resolution: {integrity: sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==}
+
   doublearray@0.0.2:
     resolution: {integrity: sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==}
 
@@ -22557,6 +22633,11 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -24635,6 +24716,9 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
@@ -24990,6 +25074,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dompurify@3.4.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   doublearray@0.0.2: {}
 
   electron-to-chromium@1.5.313: {}
@@ -25308,6 +25396,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@15.0.12: {}
 
   merge2@1.4.1: {}
 


### PR DESCRIPTION
## Summary

- `apps/markdown-to-pdf` を新規追加 — マークダウンをブラウザ印刷API経由でPDF保存できるクライアントサイドツール
- `marked` + `DOMPurify` (RETURN_DOM_FRAGMENT) + `window.print()` 方式で PDF ライブラリ不要
- `packages/router/src/config/apps.ts` に `/markdown-to-pdf` ルーティングを登録

## 機能

- リアルタイムプレビュー（マークダウン入力 → サニタイズ済みHTML表示）
- ファイルアップロード対応（.md / .markdown）＋ドラッグ＆ドロップ
- 用紙サイズ（A4 / Letter）・フォントサイズ（小 / 中 / 大）設定
- `@media print` CSS で印刷時はプレビューのみ表示、`window.print()` でPDF出力

## セキュリティ

`dangerouslySetInnerHTML` / 直接 `.innerHTML =` を一切使用しない。  
`DOMPurify.sanitize(html, { RETURN_DOM_FRAGMENT: true })` → `el.replaceChildren(fragment)` パターンで XSS 対策済み。

## Test Plan

- [ ] `cd apps/markdown-to-pdf && vp test --run` → 19/19 pass
- [ ] `vp dev` で開発サーバー起動 → マークダウン入力でリアルタイムプレビュー確認
- [ ] .md ファイルのドラッグ&ドロップ動作確認
- [ ] 「PDF として保存」→ 印刷ダイアログでPDF出力確認
- [ ] `node scripts/design-audit.js --app=markdown-to-pdf` → 違反なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)