### PR TITLE
fix(router): ルート / の404/MIMEエラーを修正（/home/ へリダイレクト）

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -23,6 +23,11 @@ app.get('/health', (c) => {
   return c.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
+// ルート(/) はランディングページ(/home/)へリダイレクト。
+// ルート直下には index.html はあるが対応する /assets/ が存在せず 404 になるため、
+// 正常稼働している /home/ に寄せる（home の og:url も /home を指す）。
+app.get('/', (c) => c.redirect('/home/', 302));
+
 // 静的ファイルを ASSETS バインディング経由で配信（secureHeaders・cors が全レスポンスに適用される）
 app.all('*', async (c) => {
   const path = new URL(c.req.url).pathname;


### PR DESCRIPTION
## 不具合

`tools.elchika.app/` で以下のエラーが発生し、トップページが**スタイル未適用**になっていた:

```
Refused to apply style from '.../assets/index-DUDTGCXP.css' because its MIME type ('application/json') ...
Failed to load resource: 404 (/assets/index-DUDTGCXP.css)
```

## 原因

- ルート `public/index.html`（2026-05-07 のコミット）が **絶対パス `/assets/...`** を参照
- しかし `public/assets/` は存在せず、実体は `public/home/assets/` にある
- Cloudflare Assets は毎デプロイで全マニフェストを置換するため `/assets/...` が 404
- ルーターの catch-all が 404 時に `c.json(...)` を返すため、CSS が `application/json` 扱いになりスタイル適用が拒否される
- コミット `2d49993` が `public/home/index.html` を相対パスへ修正した際、**ルート `public/index.html` だけ修正漏れ**だった

## 修正

正常稼働している `/home/`（HTTP 200・アセット相対参照で解決）へ寄せる:
```ts
app.get('/', (c) => c.redirect('/home/', 302));
```
home の `og:url` も既に `/home` を指しており設計と一致。アセット二重化もなく、将来の home 再ビルドにも壊れない。

## 検証（本番デプロイ済み）

- ✅ `/` → 302 → `/home/` → 最終 HTTP 200
- ✅ `/home/assets/index-DUDTGCXP.css` → HTTP 200（MIME 正常）
- ✅ `/ratio-calculator/` → HTTP 200（影響なし）

## 補足（将来の改善余地）

ルート `public/index.html` は build-all で自動生成されない手置き artifact のため、根本的には「home のビルド出力をルートにも反映する」か「この static ファイルを削除して redirect に一本化」が望ましい。本PRは最小のホットフィックス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)