### PR TITLE
fix: アセットゲートの base 判定をクォート非依存にする（SP2 の前提条件）

### DIFF
--- a/.docs/actions/next-session-asset-gate-quote.md
+++ b/.docs/actions/next-session-asset-gate-quote.md
@@ -1,0 +1,69 @@
+---
+trigger: next-session
+created: 2026-07-29
+autonomy: manual
+---
+
+# check-asset-paths.js がクォート種別で誤検知する（SP2 の前提条件）
+
+`scripts/check-asset-paths.js` は `apps/*/vite.config.ts` の `base` をソーステキストの完全一致で判定している。
+
+```js
+const EXPECTED_BASE = "'./'";          // シングルクォートを含む文字列
+const actual = m[1].replace(/,$/, '').trim();
+if (actual !== EXPECTED_BASE) { /* violation */ }
+```
+
+このため `base: "./"`（ダブルクォート）は **runtime では完全に同値なのに violation として exit 1** になる。
+
+## なぜ問題になるか
+
+`vp check --fix` を `vite.config.ts` にかけると Oxfmt がクォートを `"` に正規化する。
+root `vite.config.ts` に `fmt` 設定が無く、Oxfmt の既定が double quote のため。
+（root `vite.config.ts` 自身も `"vite-plus"` / `"happy-dom"` と double quote で書かれている）
+
+結果として「フォーマッタをかける」と「アセットパス検査が通る」が両立しない。
+SP1 では `apps/url-encoder/vite.config.ts` をフォーマット対象外にして回避したが、
+SP2 で 346 アプリの `vite.config.ts` を機械変換するため、この衝突は全アプリで顕在化する。
+
+## 実害の性質
+
+白画面事故を防ぐ最重要のゲートが、**意味を持たない字面の差異で誤検知する**。
+誤検知するゲートは「またあれか」と無視される訓練を生み、本物の違反を見逃す土壌になる。
+
+## 対応案
+
+### 案 A: check-asset-paths.js をクォート非依存にする（推奨）
+
+```js
+const actual = m[1].replace(/,$/, '').trim().replace(/^["']|["']$/g, '');
+if (actual !== './') { /* violation */ }
+```
+
+違反メッセージの期待値表示も `./` に合わせる。ゲートが意味を見るようになるので本質的。
+
+### 案 B: root vite.config.ts に fmt.singleQuote を追加する
+
+```js
+fmt: { singleQuote: true },
+```
+
+リポジトリ全体のフォーマット方針が変わる。既存 9074 ファイルの formatting issue の内訳も変わるため影響が読みにくい。
+なお CLAUDE.md の「コーディング規約」は既に「Oxfmt: single quotes」と書いており、
+**設定を追加する方がドキュメントの記述と実態が一致する**という利点はある。
+
+### 案 A + B の併用
+
+ゲートを意味ベースにしつつ、規約どおりのフォーマットに揃える。最も整合的だが影響範囲は最大。
+
+## 判断が必要な点
+
+- SP2 の着手前に決着させる必要がある（346 アプリの vite.config.ts を触るため）
+- CLAUDE.md の「Oxfmt: indent 2 spaces, single quotes, semicolons, line width 100」が
+  実態（設定なし = Oxfmt 既定 = double quote）と食い違っている件も併せて整理する
+
+## 検出の経緯
+
+SP1（`docs/superpowers/specs/2026-07-29-design-standards-adoption-design.md`）の
+Task 2 で `apps/url-encoder/vite.config.ts` に `@tailwindcss/vite` を追加し、
+scoped `vp check --fix` をかけた際に検出した。

--- a/.docs/actions/next-session-focus-ring-standards.md
+++ b/.docs/actions/next-session-focus-ring-standards.md
@@ -1,0 +1,58 @@
+---
+trigger: next-session
+created: 2026-07-29
+autonomy: manual
+---
+
+# フォーカスリングが standards §5 と異なる（344 アプリ / SP3 と併せて実施）
+
+`apps/*/src/components/ui/` の shadcn コンポーネントが v3 時代のフォーカスリング実装を持っており、
+standards `DESIGN.md` §5 が SHOULD とする形と異なる。
+
+## 実測
+
+| 項目 | 現状 | standards §5 |
+|---|---|---|
+| 実装 | `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` | `focus-visible:ring-[3px] focus-visible:ring-ring` |
+| 実 computed 外縁 | 4px（ring 2px + offset 2px） | 3px |
+| 波及範囲 | `button.tsx` だけで **344 アプリ** | — |
+
+対象コンポーネント（url-encoder で確認したもの）: `button` / `input` / `select` / `toast`、
+および `App.tsx` の `textarea` 2 箇所。
+
+## 現時点で修正していない理由
+
+- standards §5 のフォーカスリングは **SHOULD** であり MUST ではない。
+- 現状の 4px はフォーカスが**より目立つ**方向の逸脱であり、視認性の実害はない。
+  「フォーカスが見えない」という a11y の問題は発生していない。
+- SP1 のスコープは「実装方式の置換であり UI 再設計ではない」と spec に明記されており、
+  フォーカスリングの変更はその境界の外にある。
+- 1 アプリだけ直すと 345 アプリと不整合な 1 個ができるだけで、状態が悪化する。
+
+## 実施のタイミング
+
+**SP3（ThemeToggle の `packages/ui` 共通化）と併せて実施するのが自然。**
+
+346 アプリがそれぞれ `components/ui/` のコピーを持つ現状では、同じ変更を 346 回配ることになる。
+SP3 で共通コンポーネント化を進めるなら、そのタイミングで standards §5 の形に揃える方が
+作業が 1 回で済む。
+
+なお `.docs/plans/ui-commonization-design.md` に 328 アプリ分の shadcn コンポーネントを
+`packages/ui` へ集約する先行設計があるが、実際に依存しているアプリは 3 個で展開されていない。
+この件も併せて判断する必要がある。
+
+## 併せて確認すること
+
+`ring-offset-2` は `--background` を offset 色として使う（`ring-offset-background`）。
+standards §5 は「`/50` 等の透明度合成は light 背景で非テキストコントラスト 3:1（WCAG 1.4.11）を割るため使わない」
+と規定しているが、offset 方式そのものの是非には触れていない。
+3px 化する際に offset を外すことで見え方がどう変わるか、light / dark 両方で確認すること。
+
+## 検出の経緯
+
+SP1 Task 4（light / dark 目視検証）で、G6 の「フォーカスリングが 3px で見える」という
+成功基準に対し実測 4px で FAIL したことから判明した。
+成功基準は「フォーカスリングが可視であること」へ訂正し、差異を実測値付きで記録して受容した。
+
+- SP1 spec: `docs/superpowers/specs/2026-07-29-design-standards-adoption-design.md`
+- 検証記録: `.docs/verification/2026-07-29-sp1-visual-check.md`

--- a/.docs/actions/next-session-verify-script-tests.md
+++ b/.docs/actions/next-session-verify-script-tests.md
@@ -1,0 +1,64 @@
+---
+trigger: next-session
+created: 2026-07-29
+autonomy: manual
+---
+
+# scripts/ の検証スクリプトにテストが無い（SP2 前の整備候補）
+
+`scripts/verify-v4-migration.js`（SP1 で新設）を SP2 で 346 アプリの検証ゲートとして使う前に、
+このスクリプト自体の正しさをテストで固定することを検討する。
+
+## 背景
+
+SP1 で、検証コードが壊れていても気づけないことが実証された。
+
+- `verify-v4-migration.js` の G4 は当初 `builtCss.includes('oklch(0.55 0.18 255)')` で判定していた。
+  minifier が `oklch(55% .18 255)` へ正規化するため、**この判定は常に失敗する**。
+  ブランドノブは正しく届いているのに「届いていない」と報告するゲートだった。
+- 同じ時期、人手のシェル操作で複数の grep を連結した結果、
+  末尾の `printf` が `grep` の exit 1 を exit 0 へ上書きし、**無出力を「1 件ヒット」と誤記**した。
+
+どちらも「ゲートが機能しているように見えて機能していない」状態であり、
+PASS 表示からは区別できなかった。
+
+## 現状
+
+- `scripts/` にテストの置き場所も慣習も存在しない。
+- 既存の `check-asset-paths.js` / `design-audit.js` / `health-check-*.js` にもテストが無い。
+- テストは `packages/*/src/__tests__/` にのみ存在する。
+- SP1 では Task 3 Step 3 の実体破壊テスト（G4 / G5 / V3 を実際に壊して FAIL を確認）で代替した。
+  これは 1 回きりの確認であり、将来スクリプトを変更したときの回帰は検知できない。
+
+## 検討する内容
+
+`verify-v4-migration.js` を module として export できる形に分離し、各チェック関数を単体テストする。
+
+```js
+module.exports = { CHECKS, isMigrated, readBuiltCss };
+if (require.main === module) { /* CLI 部分 */ }
+```
+
+テストでは fixture を文字列として持ち、次を固定する。
+
+- 正常な生成 CSS を渡すと violation が 0 件
+- `--primary` が別の値の CSS で G4 が violation を返す
+- `--primary` を含まない CSS で G4 が violation を返す（握りつぶして PASS にしない）
+- minify 表記（`oklch(55% .18 255)`）と非 minify 表記（`oklch(0.55 0.18 255)`）の両方で G4 が PASS する
+- `hsl(var(--` を含む CSS で G3 が violation を返す
+- `base: "/"` の vite.config で G5 が violation を返す
+
+同じ整理を `check-asset-paths.js` にも適用するかは別途判断する
+（こちらは `next-session-asset-gate-quote.md` のクォート非依存化と併せて検討するのが自然）。
+
+## 判断が必要な点
+
+- `scripts/` にテスト置き場を新設するか、スクリプトを `packages/` 側へ移すか
+- SP2 の着手前に必須とするか、SP2 と並行で進めるか
+  （SP1 の破壊テストで一度は実証済みのため、ブロッカーではない）
+
+## 関連
+
+- `next-session-asset-gate-quote.md` — 同じく検証ゲートの健全性に関する項目
+- SP1 spec: `docs/superpowers/specs/2026-07-29-design-standards-adoption-design.md`
+- SP1 plan: `docs/superpowers/plans/2026-07-29-sp1-design-tokens-v4-pilot.md`

--- a/scripts/check-asset-paths.js
+++ b/scripts/check-asset-paths.js
@@ -26,7 +26,22 @@ const path = require('path');
 const REPO_ROOT = path.join(__dirname, '..');
 const APPS_DIR = path.join(REPO_ROOT, 'apps');
 const PUBLIC_DIR = path.join(REPO_ROOT, 'packages', 'router', 'public');
-const EXPECTED_BASE = "'./'";
+/** base に期待する「値」。ソース上のクォート種別は問わない（下記 stripQuotes を参照） */
+const EXPECTED_BASE = './';
+/** メッセージ表示用のリテラル表記 */
+const EXPECTED_BASE_LITERAL = `'${EXPECTED_BASE}'`;
+
+/**
+ * 文字列リテラルからクォートを外して値を取り出す。
+ * Oxfmt はクォートを正規化するため（`base: './'` → `base: "./"`）、
+ * ソーステキストの完全一致で判定すると runtime 同値でも違反と誤判定する。
+ * クォートで囲まれていない場合（変数・式など）は値を確定できないため null を返し、
+ * 呼び出し側で violation として扱う（ゲートなので fail-closed）。
+ */
+function stripQuotes(literal) {
+  const matched = literal.match(/^(['"`])(.*)\1$/);
+  return matched ? matched[2] : null;
+}
 
 const configOnly = process.argv.includes('--config-only');
 
@@ -60,13 +75,19 @@ function checkViteConfigs() {
     const m = src.match(/^\s*base\s*:\s*(.+?)\s*,?\s*$/m);
 
     if (!m) {
-      violations.push({ file: rel, issue: `base が未指定 (${EXPECTED_BASE} を明示すること)` });
+      violations.push({ file: rel, issue: `base が未指定 (${EXPECTED_BASE_LITERAL} を明示すること)` });
       continue;
     }
 
-    const actual = m[1].replace(/,$/, '').trim();
-    if (actual !== EXPECTED_BASE) {
-      violations.push({ file: rel, issue: `base: ${actual} → ${EXPECTED_BASE} でなければならない` });
+    const raw = m[1].replace(/,$/, '').trim();
+    const actual = stripQuotes(raw);
+    if (actual === null) {
+      violations.push({
+        file: rel,
+        issue: `base: ${raw} は文字列リテラルでないため値を確定できない (${EXPECTED_BASE_LITERAL} を直接書くこと)`,
+      });
+    } else if (actual !== EXPECTED_BASE) {
+      violations.push({ file: rel, issue: `base: ${raw} → ${EXPECTED_BASE_LITERAL} でなければならない` });
     }
   }
 
@@ -125,7 +146,9 @@ function main() {
 
   const configViolations = checkViteConfigs();
   const appCount = fs.existsSync(APPS_DIR) ? listDirs(APPS_DIR).length : 0;
-  console.log(`  vite.config.ts : ${appCount - configViolations.length} / ${appCount} が base: ${EXPECTED_BASE}`);
+  console.log(
+    `  vite.config.ts : ${appCount - configViolations.length} / ${appCount} が base: ${EXPECTED_BASE_LITERAL}`
+  );
   violations = violations.concat(configViolations);
 
   if (!configOnly) {


### PR DESCRIPTION
`scripts/check-asset-paths.js` が `base` をソーステキストの完全一致で判定しており、
Oxfmt がクォートを正規化すると **runtime 同値なのに違反判定**になる問題を修正する。

## 問題

```js
const EXPECTED_BASE = "'./'";                       // シングルクォートを含む文字列
const actual = m[1].replace(/,$/, '').trim();
if (actual !== EXPECTED_BASE) { /* violation */ }
```

`vp check --fix` を `vite.config.ts` にかけると Oxfmt がクォートを `"` へ正規化するため、
`base: "./"` が違反になる。root `vite.config.ts` に `fmt` 設定が無く Oxfmt 既定が
double quote であることが背景（root 自身も `"vite-plus"` と double quote で書かれている）。

**白画面事故を防ぐ最重要のゲートが、意味を持たない字面の差異で誤検知する**状態だった。
誤検知するゲートは「またあれか」と無視される訓練を生み、本物の違反を見逃す土壌になる。

## 修正

クォートを剥がして値で比較する。文字列リテラルでない場合（変数・式など）は
値を確定できないため violation とする（ゲートなので fail-closed）。

## 検証

各コマンドを個別に実行し、両方向を確認した。

| 入力 | 期待 | 結果 |
|---|---|---|
| `base: './'`（346 アプリ） | PASS | 346/346 PASS |
| `base: "./"` | **PASS** | PASS（**修正前は違反判定された入力**） |
| `base: "/"` | 違反 | `base: "/" → './' でなければならない` |
| `base: process.env.BASE` | 違反 | `文字列リテラルでないため値を確定できない` |

`vp check --no-fmt` は lint/type エラー 0。
formatting issue は変更前から存在するもので（既存 9074 件の 1 つ）、
`--fix` をかけると無関係な整形差分が出るため適用していない。

## 背景

SP1（#848）で 346 アプリの Tailwind v4 移行手順を確定させた際に判明した。
移行では全アプリの `vite.config.ts` に `@tailwindcss/vite` を追加するため、
このゲートを直さないと **SP2 で全アプリが誤検知で落ちる**。

SP1 では該当ファイルを整形対象外にして回避したが、根本解決はこちら。

## 併せて含むもの

SP1 で起票した Action 3 件（`.docs/actions/`）。

- `next-session-asset-gate-quote.md` — **本 PR で解決**。マージ後に done にする
- `next-session-focus-ring-standards.md` — フォーカスリングの standards §5 準拠（344 アプリ / SP3 と併せて）
- `next-session-verify-script-tests.md` — 検証スクリプトのテスト整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)